### PR TITLE
Nettoyage du thesaurus des termes

### DIFF
--- a/thesaurus_terms.csv
+++ b/thesaurus_terms.csv
@@ -1,62 +1,27 @@
-&#8220,&#8220
-(hidden) conditional random fields,(hidden) conditional random fields
+label,replace by
 10-Fold Cross-Validation,10-fold cross-validation
-1D Convolution,1D Convolution
 1D-LDA,1D LDA
 1D-LSTM,1D LSTM
-1D paths,1D paths
-1ST-GRADE,1ST-GRADE
-1ST-GRADERS,1ST-GRADERS
-2D architectural floor plans,2D architectural floor plans
 2D-grammar,2D grammar
 2DLSTM,2D LSTM
 2D-LSTM,2D LSTM
 2D Self-sttention,2D self-attention
 2-D SHAPE MATCHING,2D shape matching
-3 axis accelerometer,3 axis accelerometer
 3-axis accelerometer,3 axis accelerometer
-3D air-writing,3D air-writing
-3D feature,3D feature
-3D hand tracking,3D hand tracking
 3D Handwriting,3D handwriting
 3D handwriting recognition,3D handwriting
 3D-handwritten character recognition,3D handwritten character recognition
-3D motion tracking,3D motion tracking
-3D Sketching,3D Sketching
-3D space handwriting,3D space handwriting
-3D structures of plants,3D structures of plants
-3G smartphones,3G smartphones
 and 6 sigma,6 Sigma
-60 GHz,60 GHz
-6-DOF motion,6-DOF motion
-A deep Q-network strategy,A deep Q-network strategy
-a multiple Fermat's spiral,a multiple Fermat's spiral
-A* path-planning algorithm,A* path-planning algorithm
-Abbreviations,Abbreviations
 ABILITIES,Abilities
 ABILITY,Abilities
-Absolute difference Difference ratio,Absolute difference Difference ratio
-Abstract Syntax Tree,Abstract Syntax Tree
 ABSTRACTIONIST,Abstractionist
-Academic/literate language,Academic/literate language
 ACCELERATION,Acceleration
-Acceleration,Acceleration
-acceleration sensor,acceleration sensor
-Accelerators,Accelerators
-Accelerometer,Accelerometer
 accelerometer,Accelerometer
 Accelerometers,Accelerometer
-accelerometer-based input device,accelerometer-based input device
-Accented characters,Accented characters
 ACCESS,Access
-Access control,Access control
 ACCOUNT,Account
-Account security,Account security
-accounting system,accounting system
 ACCURACY,Accuracy
-Accuracy,Accuracy
 accuracy,Accuracy
-Accuracy prediction,Accuracy prediction
 ACCURATE,Accurate
 ACHIEVEMENT,Achievement
 Acoustic feature modeling,Acoustic Feature Modeling
@@ -64,15 +29,12 @@ acoustic model,Acoustic Model
 Acoustic sensing,Acoustic Sensing
 acoustic signal,Acoustic Signal
 ACQUISITION,Acquisition
-Acquisition Device Comparison,Acquisition Device Comparison
 acquisition devices,Acquisition Devices
-ACRC 2021,ACRC 2021
 acrostic poem generation,Acrostic Poem Generation
 Action planning,Action Planning
 action understanding,Action Understanding
 AcTiV dataset,Activ Dataset
 ACTIVATION,Activation
-Activation Function,Activation Function
 Activation function,Activation Function
 activation function,Activation Function
 Activation Functions,Activation Function
@@ -83,7 +45,6 @@ Active feedback,Active Feedback
 Active learning,Active Learning
 active learning,Active Learning
 active set,Active Set
-Active Shape Model,Active Shape Model
 Active shape model,Active Shape Model
 ACTIVE SHAPE MODELS,Active Shape Model
 Active Shape Models,Active Shape Model
@@ -91,22 +52,17 @@ Active-learning set-up,Active Learning Set-Up
 ACTIVITY RECOGNITION,Activity Recognition
 Activity recognition,Activity Recognition
 acute phenylalanine and tyrosine depletion,Acute Phenylalanine And Tyrosine Depletion
-ADAB,ADAB
 ADAB database,ADAB Database
 ADAB-database,ADAB Database
-AdaBoost,AdaBoost
 Adaboost,AdaBoost
 Ada-boost,AdaBoost
 AdaBoost algorithm,AdaBoost
 AdaBoostClassifier,AdaBoost classifier
-Adam Optimizer,Adam Optimizer
 adaptability,Adaptability
 ADAPTATION,Adaptation
-Adaptation,Adaptation
 adaptation,Adaptation
 Adaptation models,Adaptation Models
 adapted saliency values,Adapted Saliency Values
-Adaptive,Adaptive
 adaptive binarization,Adaptive Binarization
 Adaptive boosting,Adaptive Boosting
 adaptive classifier,Adaptive Classifier
@@ -114,12 +70,9 @@ adaptive classifiers,Adaptive Classifier
 adaptive committee,Adaptive Committee
 Adaptive data augmentation,Adaptive Data Augmentation
 adaptive delay matching,Adaptive Delay Matching
-Adaptive Density Partitioning,Adaptive Density Partitioning
 adaptive gradient methods,Adaptive Gradient Methods
 Adaptive graph regularization,Adaptive Graph Regularization
 adaptive handwriting recognition,Adaptive Handwriting Recognition
-Adaptive Kernel,Adaptive Kernel
-Adaptive Learning,Adaptive Learning
 Adaptive learning rate,Adaptive Learning Rate
 adaptive length Viterbi algorithm (ALVA),Adaptive Length Viterbi Algorithm
 adaptive local connectivity map (ALCM),Adaptive Local Connectivity Map
@@ -131,7 +84,6 @@ adaptive neuro-fuzzy classifier,Adaptive Neuro-Fuzzy Classifier
 ADAPTIVE NONLINEAR SHAPE MATCHING,Adaptive Nonlinear Shape Matching
 ADAPTIVE NORMALIZATION,Adaptive Normalization
 adaptive recognition,Adaptive Recognition
-Adaptive Resonance Theory,Adaptive Resonance Theory
 adaptive sparse representation approach,Adaptive Sparse Representation Approach
 adaptive sparse representation framework,Adaptive Sparse Representation Framework
 adaptive structuring elements,Adaptive Structuring Elements
@@ -139,14 +91,12 @@ adaptive systems,Adaptive Systems
 adaptive threshold,Adaptive Threshold
 Adaptive training,Adaptive Training
 ADBase,Adbase
-Added Strokes,Added Strokes
 ADDER,Adder
 Adders,Adder
 ADDRESS INTERPRETATION,Address Interpretation
 address interpretation,Address Interpretation
 ADDRESS RECOGNITION,Address Recognition
 ADDRESSES,Addresses
-ADHD,ADHD
 attention deficit hyperactivity disorder,ADHD
 ADHESIVE,Adhesive
 adjustable-order statistic filters (AOSFs),Adjustable-Order Statistic Filters
@@ -157,38 +107,30 @@ ADULT CHRONIC RHINOSINUSITIS,Adult Chronic Rhinosinusitis
 ADULTS,Adults
 Advanced convolutional neural networks,Advanced Convolutional Neural Networks
 Advanced modeling,Advanced Modeling
-Advanced Vector Extensions,Advanced Vector Extensions
 Adversarial feature learning,Adversarial Feature Learning
-Adversarial Learning,Adversarial Learning
 adversarial learning,Adversarial Learning
 ADVERSARIAL NETWORKS,Adversarial Networks
 ADVERSE DRUG EVENTS,Adverse Drug Events
 AE1 algorithm,AE1 Algorithm
 AEC Drawing Documents,AEc Drawing Documents
-Aerial Handwriting,Aerial Handwriting
 aesthetic analysis,Aesthetic Analysis
-Aesthetic Evaluation,Aesthetic Evaluation
 Aesthetic quality,Aesthetic Quality
 AEVIOUS sliding keyboard,Aevious Sliding Keyboard
 Affect Labels and Ground Truth,Affect Labels And Ground Truth
 AFFINE,Affine
 Affine moment invariant,Affine Moment Invariant
 affine transform,Affine Transform
-Affine Transformation,Affine Transformation
 affine transformations,Affine Transformation
 Affine-invariant template matching,Affine-Invariant Template Matching
 affine-invariant template matching,Affine-Invariant Template Matching
 affinity propagation,Affinity Propagation
 Affinity propagation clustering,Affinity Propagation Clustering
 AFS theory,AFS Theory
-AG,AG
 AGE,Age
-Age,Age
 AGE ESTIMATION,Age Estimation
 age estimation,Age Estimation
 age group classification,Age Group Classification
 age prediction,Age Prediction
-Agents,Agents
 Agglomerative clustering,Agglomerative Clustering
 Agglomerative hierarchical clustering,Agglomerative Hierarchical Clustering
 agglutinative,Agglutinative
@@ -198,17 +140,11 @@ agile development,Agile Development
 aging,Aging
 AGNOSIA,Agnosia
 AGRAPHIA,Agraphia
-Agraphia,Agraphia
 agraphia,Agraphia
 AGREEMENT,Agreement
 AGRICULTURE,Agriculture
-AHCD,AHCD
-AHCR Database,AHCR Database
-AHDB,AHDB
 AHTED/MW database,AHTED/MW Database
-AHTID/MW Database,AHTID/MW Database
 AHTID/MW database,AHTID/MW Database
-AI,AI
 AIR,Air
 air-handwriting,Air-Handwriting
 Air-writing,Air-Writing
@@ -217,11 +153,7 @@ Air-write recognition,Air-Writing Recognition
 Air-writing Recognition,Air-Writing Recognition
 Air-writing recognition,Air-Writing Recognition
 Akaike information criterion,Akaike Information Criterion
-Akharamuni,Akharamuni
 Akkharamuni,Akharamuni
-Al-Algorithm,Al-Algorithm
-Alerting System,Alerting System
-AlexNet,AlexNet
 Alexnet,AlexNet
 algebraic curves,Algebraic Curves
 ALGORITHM,Algorithm
@@ -229,9 +161,7 @@ algorithm,Algorithm
 algorithm design and analysis,Algorithm Design And Analysis
 algorithm efficiency,Algorithm Efficiency
 Algorithmic optimization,Algorithmic Optimization
-Algorithmic Problem Solving,Algorithmic Problem Solving
 ALGORITHMS,Algorithms
-Algorithms,Algorithms
 aligning handwriting and transcript dynamic,Aligning Handwriting And Transcript Dynamic
 ALIGNMENT,Alignment
 alignment,Alignment
@@ -239,7 +169,6 @@ ALLOCATION,Allocation
 allograph,Allograph
 allograph clustering,Allograph Clustering
 allograph matching,Allograph Matching
-Allographs,Allographs
 alphabet,Alphabet
 alphabet discrimination,Alphabet Discrimination
 alphabet formation,Alphabet Formation
@@ -263,8 +192,6 @@ amazon elastic mapreduce,Amazon Elastic Mapreduce
 ambiguous signature patterns,Ambiguous Signature Patterns
 Ambiguous zone,Ambiguous Zone
 ambiguous zone,Ambiguous Zone
-Amharic,Amharic
-Amharic Document Image,Amharic Document Image
 AMINO-ACID MIXTURE,Amino-Acid Mixture
 AMOUNT RECOGNITION,Amount Recognition
 amount recognition,Amount Recognition
@@ -273,7 +200,6 @@ AMYGDALA,Amygdala
 anaesthesia,Anaesthesia
 Analog and digital,Analog And Digital
 analogic spatio-temporal algorithms,Analogic Spatio-Temporal Algorithms
-Analysis,Analysis
 analysis,Analysis
 analysis of the structure,Analysis Of The Structure
 ANALYSIS SYSTEM,Analysis System
@@ -288,7 +214,6 @@ Ancient document recognition,Ancient Document Recognition
 ancient Greek inscription classification,Ancient Greek Inscription Classification
 Ancient manuscripts,Ancient Manuscript
 Ancient text transcription,Ancient Text Transcription
-Android,Android
 Android device,Android Device
 Android handwriting recognition,Android Handwriting Recognition
 ANESTHESIA RECORDS,Anesthesia Records
@@ -304,24 +229,17 @@ Annotation,Annotations
 annotation,Annotations
 annotations,Annotations
 Anomaly detection,Anomaly Detection
-Anomaly Handling,Anomaly Handling
 Anomaly handling,Anomaly Handling
 Anonymization enhancement,Anonymization Enhancement
 ANOSOGNOSIA,Anosognosia
-Anoto,Anoto
 Anoto digital pen,Anoto Digital Pen
-Answer Box Recognition,Answer Box Recognition
 Answer script evaluation,Answer Script Evaluation
-Ant-Colony Optimization,Ant-Colony Optimization
-Antibodies,Antibodies
 ANTICIPATION,Anticipation
 anticipation,Anticipation
 anti-cursive curve characters,Anti-Cursive Curve Characters
-Antigens,Antigens
 anti-likelihood,Anti-Likelihood
 ANWRESH,Anwresh
 ANXIETY,Anxiety
-AnYa type fuzzy rule-based (FRB) classifiers,AnYa type fuzzy rule-based (FRB) classifiers
 Anytime anywhere document analysis,Anytime Anywhere Document Analysis
 APART,Apart
 appearance,Appearance
@@ -331,7 +249,6 @@ Applicability domain,Applicability Domain
 Applications of deep learning to document analysis,Applications Of Deep Learning To Document Analysis
 applications specific array processors (ASAP),Applications Specific Array Processors
 approximate 4-2 compressors,Approximate 4-2 Compressors
-Approximate Computing,Approximate Computing
 Approximate computing,Approximate Computing
 approximate computing,Approximate Computing
 approximate distances,Approximate Distances
@@ -349,13 +266,10 @@ approximation factors,Approximation Factors
 approximation theory,Approximation Theory
 APPROXIMATIONS,Approximations
 Aquila optimizer,Aquila Optimizer
-AR2U-Net,AR2U-Net
-Arabic,Arabic
 Arabic (Indian) automatic numeral recognition,Arabic (Indian) Automatic Numeral Recognition
 Arabic (Indian) digits,Arabic (Indian) Digits
 Arabic (Indian) numerals,Arabic (Indian) Numerals
 Arabic alphabets,Arabic Alphabets
-Arabic and Latin,Arabic and Latin
 Arabic calligraphy handwriting,Arabic Calligraphy Handwriting
 Arabic CAPTCHA,Arabic Captcha
 Arabic character models,Arabic Character Models
@@ -368,43 +282,31 @@ Arabic characters,Arabic Characters
 Arabic cheque processing,Arabic Cheque Processing
 ARABIC CURSIVE CHARACTERS,Arabic Cursive Characters
 Arabic cursive handwriting,Arabic Cursive Handwriting
-Arabic Database,Arabic Database
 Arabic datasets,Arabic Datasets
-Arabic Digit Recognition,Arabic Digit Recognition
 Arabic document processing,Arabic Document Processing
 Arabic document,Arabic Documents
-Arabic Documents,Arabic Documents
 Arabic Font recognition,Arabic Font Recognition
-Arabic Handwriting,Arabic Handwriting
 Arabic handwriting,Arabic Handwriting
 Arabic handwritings,Arabic Handwriting
 Arabic handwriting databases,Arabic Handwriting Database
 ARABIC HANDWRITING RECOGNITION,Arabic Handwriting Recognition
-Arabic Handwriting Recognition,Arabic Handwriting Recognition
 Arabic Handwriting recognition,Arabic Handwriting Recognition
 Arabic handwriting recognition,Arabic Handwriting Recognition
 arabic handwriting recognition,Arabic Handwriting Recognition
 Arabic handwriting recognition (AHR),Arabic Handwriting Recognition
 Arabic handwriting recognition competition,Arabic Handwriting Recognition Competition
-Arabic Handwriting Recognition System,Arabic Handwriting Recognition System
-Arabic Handwriting Segmentation,Arabic Handwriting Segmentation
 Arabic handwriting word recognition,Arabic Handwriting Word Recognition
-Arabic Handwritten,Arabic Handwritten
 Arabic handwritten,Arabic Handwritten
 Arabic handwritten character recognition,Arabic Handwritten Character Recognition
 Arabic Handwritten Character Recognition (AHCR),Arabic Handwritten Character Recognition
 Arabic handwritten characters recognition,Arabic Handwritten Character Recognition
 Arabic handwritten characters,Arabic Handwritten Characters
-Arabic Handwritten Documents,Arabic Handwritten Documents
-Arabic Handwritten Recognition,Arabic Handwritten Recognition
 Arabic handwritten recognition,Arabic Handwritten Recognition
 arabic handwritten recognition,Arabic Handwritten Recognition
 Arabic Handwritten Recognition (AHR),Arabic Handwritten Recognition
-Arabic Handwritten Script,Arabic Handwritten Script
 Arabic handwritten script,Arabic Handwritten Script
 arabic handwritten script,Arabic Handwritten Script
 Arabic handwritten text,Arabic Handwritten Text
-Arabic Handwritten Text Database,Arabic Handwritten Text Database
 Arabic handwritten text database,Arabic Handwritten Text Database
 Arabic Handwritten text image,Arabic Handwritten Text Image
 Arabic handwritten text recognition,Arabic Handwritten Text Recognition
@@ -417,7 +319,6 @@ Arabic language,Arabic Language
 Arabic letter morphology,Arabic Letter Morphology
 Arabic letters,Arabic Letters
 Arabic license plate character recognition,Arabic License Plate Character Recognition
-Arabic Ligatures,Arabic Ligatures
 Arabic ligatures,Arabic Ligatures
 Arabic linguistics,Arabic Linguistics
 Arabic literal amount recognition,Arabic Literal Amount Recognition
@@ -427,24 +328,17 @@ Arabic numeral,Arabic Numeral
 Arabic numerals,Arabic Numerals
 arabic numerals,Arabic Numerals
 Arabic numerals recognition,Arabic Numerals Recognition
-Arabic OCR,Arabic OCR
 Arabic optical Character Recognition(AOCR),Arabic OCR
 arabic OCR survey,Arabic OCR Survey
-Arabic OCR/OPR,Arabic OCR/OPR
 Arabic offline handwriting recognition,Arabic Offline Handwriting Recognition
-Arabic Offline Handwritten Recognition,Arabic Offline Handwritten Recognition
 Arabic online database,Arabic Online Database
 arabic online digit recognition,Arabic Online Digit Recognition
 arabic online handwriting databases,Arabic Online Handwriting Databases
 Arabic online handwriting recognition,Arabic Online Handwriting Recognition
 Arabic optical handwritten numeral recognition,Arabic Optical Handwritten Numeral Recognition
-Arabic Optical Printed Text Recognition,Arabic Optical Printed Text Recognition
 Arabic personal names,Arabic Personal Names
 arabic printed OCR,Arabic Printed OCR
-Arabic Printed Text,Arabic Printed Text
-Arabic Recognition,Arabic Recognition
 Arabic recognition,Arabic Recognition
-Arabic Script,Arabic Script
 Arabic script,Arabic Script
 Arabic script layout analysis,Arabic Script Layout Analysis
 Arabic script segmentation,Arabic Script Segmentation
@@ -452,43 +346,30 @@ Arabic sub-core shapes,Arabic Sub-Core Shapes
 Arabic subword,Arabic Subword
 Arabic Sub-word,Arabic Subword
 Arabic sub-word recognition,Arabic Subword Recognition
-Arabic Text,Arabic Text
 Arabic text,Arabic Text
-Arabic Text Detection,Arabic Text Detection
-Arabic Text Recognition,Arabic Text Recognition
 Arabic text recognition,Arabic Text Recognition
 arabic text recognition,Arabic Text Recognition
-Arabic Video OCR,Arabic Video OCR
 Arabic word recognition,Arabic Word Recognition
 arabic word recognition,Arabic Word Recognition
 Arabic word,Arabic Words
 Arabic words,Arabic Words
 Arabic writer identification,Arabic Writer Identification
-Arabization,Arabization
-ARBFN,ARBFN
-Archaeology,Archaeology
 archaeology,Archaeology
 Archimedes' spiral,Archimedes' Spiral
 ARCHITECTURE,Architecture
-Architecture,Architecture
 ARCHITECTURES,Architectures
 Architectures for educational technology systems,Architectures For Educational Technology Systems
 Archival Card Index (ACI),Archival Card Index
 archive document,Archive Document
 Archive document processing,Archive Document Processing
-Archives,Archives
 Arduino mega board,Arduino Mega Board
 Arduino TFT touch screen,Arduino TFT Touch Screen
 AREA,Area
-Area,Area
 AREA DIVISION,Area Division
 Area Voronoi diagram,Area Voronoi Diagram
 Arithmetical operation analysis,Arithmetical Operation Analysis
 arithmetical operation analysis,Arithmetical Operation Analysis
-Ariyaka,Ariyaka
 Ariyaka script,Ariyaka Script
-ARM,ARM
-Armenian,Armenian
 Arnold transform,Arnold Transform
 ARRAY,Array
 ARRAY PROCESSOR,Array Processor
@@ -505,10 +386,8 @@ artificial bee colony optimization,Artificial Bee Colony Optimization
 artificial character distortion,Artificial Character Distortion
 artificial database,Artificial Database
 artificial error,Artificial Error
-Artificial Immune Recognition System,Artificial Immune Recognition System
 Artificial immune systems,Artificial Immune Systems
 ARTIFICIAL INTELLIGENCE,Artificial Intelligence
-Artificial Intelligence,Artificial Intelligence
 Artificial intelligence,Artificial Intelligence
 artificial intelligence,Artificial Intelligence
 Artificial intelligence accelerators,Artificial Intelligence Accelerators
@@ -521,7 +400,6 @@ ANN MODEL,Artificial Neural Network
 ART Neural Networks,Artificial Neural Network
 ART1 network,Artificial Neural Network
 ART-2 neural network,Artificial Neural Network
-Artificial Neural Network,Artificial Neural Network
 Artificial neural network,Artificial Neural Network
 artificial neural network,Artificial Neural Network
 Artificial Neural Network (ANN),Artificial Neural Network
@@ -538,11 +416,8 @@ Artificial Skin interfaces,Artificial Skin Interfaces
 ARTIST,Artist
 ARTMAP,Artmap
 AS-A-SERVICE,As-A-Service
-Ascender,Ascender
 Asian character recognition,Asian Character Recognition
 aspect ratio function,Aspect Ratio Function
-ASR,ASR
-Assamese,Assamese
 Assamese database,Assamese Database
 Assamese handwritten digit recognition,Assamese Handwritten Digit Recognition
 Assamese language,Assamese Language
@@ -551,13 +426,11 @@ ASSIGNMENT,Assignment
 assistance system,Assistance System
 assisted transcription,Assisted Transcription
 assistive environment,Assistive Environment
-Assistive Technology,Assistive Technology
 Assistive technology,Assistive Technology
 association of strokes,Association Of Strokes
 ASSOCIATION RATIOS,Association Ratios
 associative indexing,Associative Indexing
 ASSOCIATIVE MEMORY,Associative Memory
-Associative Memory,Associative Memory
 Associative memory,Associative Memory
 associative memory,Associative Memory
 ASSURANCE,Assurance
@@ -566,15 +439,12 @@ ASTRO-WISE,Astro-Wise
 asymmetric Mahalanobis distance,Asymmetric Mahalanobis Distance
 asynchronous circuit,Asynchronous Circuit
 asynchronous design flow,Asynchronous Design Flow
-ATBM,ATBM
 ATM authentication,ATM Authentication
 ATM security,ATM Security
 ATM transaction,ATM Transaction
 atomic character classes,Atomic Character Classes
-ATR,ATR
 Atrous convolution,Atrous Convolution
 ATTENTION,Attention
-Attention,Attention
 attention,Attention
 Attention mechanism,Attention Mechanism
 attention mechanism,Attention Mechanism
@@ -585,7 +455,6 @@ ATTENTIONAL COST,Attentional Cost
 ATTENTIONAL MODULATION,Attentional Modulation
 attention-based approach,Attention-Based Approach
 attention-CNN model (AT-CNN model),Attention-CNN Model
-Attentiveness,Attentiveness
 ATTITUDES,Attitudes
 attribute graph,Attribute Graph
 Attribute-based Classification Method,Attribute-Based Classification Method
@@ -595,23 +464,16 @@ attributed relational graph,Attributed Relational Graph
 ATTRIBUTED RELATIONAL GRAPHS,Attributed Relational Graph
 ATTRIBUTES,Attributes
 ATTRIBUTIONS,Attributions
-Audio Signals,Audio Signals
-Audio-Video Combination,Audio-Video Combination
-Augmentation,Augmentation
 augmented Lagrangian method,Augmented Lagrangian Method
 Augmented pen,Augmented Pen
 Augmented reality,Augmented Reality
 augmented reality,Augmented Reality
 augmented signature,Augmented Signature
-AU-Net,AU-Net
 AUTHENTICATION,Authentication
-Authentication,Authentication
 authentication,Authentication
 author identification,Author Identification
 authorship,Authorship
-Auto Associative Memory,Auto Associative Memory
 Auto translation error map,Auto Translation Error Map
-Autoencoder,Autoencoder
 autoencoder,Autoencoder
 auto-encoder,Autoencoder
 AutoEncoder (AE),Autoencoder
@@ -629,7 +491,6 @@ automated design system,Automated Design System
 automated detection,Automated Detection
 AUTOMATED DOCUMENT PROCESSING,Automated Document Processing
 Automated essay grading,Automated Essay Grading
-Automated Form Processing,Automated Form Processing
 automated inscriber identification,Automated Inscriber Identification
 automated letter-cutter identification,Automated Letter-Cutter Identification
 Automated measuring system,Automated Measuring System
@@ -637,7 +498,6 @@ automated record keeping,Automated Record Keeping
 automated record-keeping,Automated Record Keeping
 automated text recognition,Automated Text Recognition
 Automatic abstraction,Automatic Abstraction
-Automatic Alignment,Automatic Alignment
 automatic anaesthesia record,Automatic Anaesthesia Record
 Automatic answer evaluation,Automatic Answer Evaluation
 Automatic assessment,Automatic Assessment
@@ -660,7 +520,6 @@ automatic essay scoring,Automatic Essay Scoring
 automatic estimation,Automatic Estimation
 Automatic evaluation,Automatic Evaluation
 AUTOMATIC EXTRACTION,Automatic Extraction
-Automatic Feature,Automatic Feature
 automatic feature selection,Automatic Feature Selection
 automatic feedback and analysis,Automatic Feedback And Analysis
 Automatic fuzzy modeling,Automatic Fuzzy Modeling
@@ -671,11 +530,9 @@ Automatic image recognition,Automatic Image Recognition
 AUTOMATIC IMITATION,Automatic Imitation
 automatic indexing,Automatic Indexing
 automatic information processing,Automatic Information Processing
-Automatic Label Extraction,Automatic Label Extraction
 Automatic labeling,Automatic Labeling
 Automatic language recognition,Automatic Language Recognition
 automatic learning,Automatic Learning
-Automatic Lighting,Automatic Lighting
 automatic location,Automatic Location
 Automatic mail sorting,Automatic Mail Sorting
 Automatic Multi-lingual Script Recognition (AMSR),Automatic Multi-Lingual Script Recognition
@@ -692,13 +549,11 @@ automatic rule generation,Automatic Rule Generation
 AUTOMATIC SCRIPT IDENTIFICATION,Automatic Script Identification
 Automatic segmentation,Automatic Segmentation
 AUTOMATIC SIGNATURE VERIFICATION,Automatic Signature Verification
-Automatic Signature Verification,Automatic Signature Verification
 Automatic signature verification,Automatic Signature Verification
 automatic signature verification,Automatic Signature Verification
 Automatic Signature Verification (ASV),Automatic Signature Verification (Asv)
 automatic signature verification (ASV),Automatic Signature Verification (Asv)
 AUTOMATIC SPEECH RECOGNITION,Automatic Speech Recognition
-Automatic Speech Recognition,Automatic Speech Recognition
 Automatic speech recognition,Automatic Speech Recognition
 automatic speech recognition,Automatic Speech Recognition
 Automatic Speech Recognition (ASR),Automatic Speech Recognition (Asr)
@@ -722,13 +577,10 @@ Automatic writing,Automatic Writing
 AUTOMATIC-ANALYSIS,Automatic-Analysis
 AUTOMATIC-GENERATION,Automatic-Generation
 AUTOMATICITY,Automaticity
-Automaticity,Automaticity
 automaticity,Automaticity
 AUTOMATION,Automation
-Automation,Automation
 automation,Automation
 automation of banking systems,Automation Of Banking Systems
-Automotion,Automotion
 autonomous agent,Autonomous Agent
 AUTONOMOUS VEHICLES,Autonomous Vehicles
 Auto-regressive model coefficients,Auto-Regressive Model Coefficients
@@ -736,10 +588,6 @@ auto-scaling,Auto-Scaling
 Auto-weighter,Auto-Weighter
 averaging,Averaging
 AWARENESS,Awareness
-AWFO,AWFO
-AWHR,AWHR
-Axiomatic Fuzzy Set Theory,Axiomatic Fuzzy Set Theory
-Back Propagation,Back Propagation
 Back propagation,Back Propagation
 back propagation,Back Propagation
 BACKPROPAGATION,Back Propagation
@@ -747,7 +595,6 @@ Backpropagation,Back Propagation
 backpropagation,Back Propagation
 Back-propagation,Back Propagation
 back-propagation,Back Propagation
-Back Propagation Algorithm,Back Propagation Algorithm
 Back Propagation algorithm,Back Propagation Algorithm
 Back propagation algorithm,Back Propagation Algorithm
 Backpropagation Algorithm,Back Propagation Algorithm
@@ -759,20 +606,17 @@ Back propagation learning,Back Propagation Learning
 Back Propagation Neural Network,Back Propagation Learning
 back propagation neural network,Back Propagation Learning
 Backpropagation learning,Back Propagation Learning
-Back Propagation Network,Back Propagation Network
 Back Propagation Network (BPN),Back Propagation Network
 backpropagation network,Back Propagation Network
 Back-propagation neural network,Back Propagation Network
 back-propagation neural network,Back Propagation Network
 Back-propagation neural network (BPNN),Back Propagation Network
-Background Elimination,Background Elimination
 Background estimation,Background Estimation
 background estimation,Background Estimation
 background feature,Background Feature
 Background feature descriptor,Background Feature Descriptor
 background feature extraction,Background Feature Extraction
 background features,Background Features
-Background Information,Background Information
 backuround removal,Background Removal
 BACK-OFFICE PROCESSING,Back-Office Processing
 The Back-propagation Artificial Neural Network,Back-Propagation Artificial Neural Network
@@ -784,45 +628,31 @@ Bag of histogram,Bag Of Histogram
 Bag of notes,Bag Of Notes
 bag of symbols,Bag Of Symbols
 Bag of Words,Bag Of Words
-Bagging,Bagging
 bagging,Bagging
 Balinese script,Balinese Script
 BALLOON,Balloon
 Ballpoint pen,Ballpoint Pen
 balls of words,Balls Of Words
-BAM,BAM
 Band selection,Band Selection
 bands of super-states,Bands Of Super-States
-Bangia Script Recognition,Bangia Script Recognition
 BANGLA,Bangla
-Bangla,Bangla
 bangla basic characters numerals and vowel modifiers,Bangla Basic Characters Numerals And Vowel Modifiers
 BANGLA CHARACTER,Bangla Character
 Bangla character,Bangla Character
 BANGLA CHARACTERS,Bangla Character
-Bangla Character Recognition,Bangla Character Recognition
 Bangla character recognition,Bangla Character Recognition
 Bangles character recognition,Bangla Character Recognition
-Bangla Compound Character,Bangla Compound Character
 Bangla Compound character,Bangla Compound Character
 Bangla compound character,Bangla Compound Character
 Bangla handwritten characters,Bangla Compound Character
-Bangla Digit Recognition,Bangla Digit Recognition
 Bangla handwriting,Bangla Handwriting
 Bangla handwriting database,Bangla Handwriting Database
-Bangla Handwriting Recognition,Bangla Handwriting Recognition
 Bangla handwriting recognition,Bangla Handwriting Recognition
-Bangla Handwritten Character Recognition,Bangla Handwritten Character Recognition
 Bangla handwritten character recognition,Bangla Handwritten Character Recognition
-Bangla Handwritten Digit Recognition,Bangla Handwritten Digit Recognition
-Bangla Numeral,Bangla Numeral
 Bangla numeral recognition,Bangla Numeral Recognition
 bangla numeral recognition,Bangla Numeral Recognition
-Bangla Optical Character Recognition,Bangla Optical Character Recognition
 Bangla script,Bangla Script
 bangla script,Bangla Script
-Bangla Script Recognition,Bangla Script Recognition
-Bangla Text,Bangla Text
 Bangla vowel modifiers,Bangla Vowel Modifiers
 Bangla word images,Bangla Word Images
 banglalekha dataset,Banglalekha Dataset
@@ -846,13 +676,11 @@ BASAL GANGLIA,Basal Ganglia
 BASE,Base
 Based-handwriting recognition,Based-Handwriting Recognition
 based-SVM,Based-SVM
-Baseline,Baseline
 baseline,Baseline
 Baseline detection,Baseline Detection
 baseline detection,Baseline Detection
 Baseline estimation,Baseline Estimation
 baseline rules,Baseline Rules
-Baseline Text Detection,Baseline Text Detection
 Baselin-dependent percentile,Baseline-Dependent Percentile
 baseline-independent,Baseline-Independent
 basic educational application,Basic Educational Application
@@ -867,7 +695,6 @@ Baum-Welch,Baum-Welch Algorithm
 Baum-Welch algorithm,Baum-Welch Algorithm
 Baum-welch algorithm,Baum-Welch Algorithm
 baybayin,Baybayin
-Bayes Algorithm,Bayes Algorithm
 Bayes classification,Bayes Classification
 Bayes classifier,Bayes Classification
 BAYESIAN CLASSIFICATION,Bayes Classification
@@ -879,16 +706,13 @@ Bayes modeling,Bayes Modeling
 Bayesian modeling,Bayes Modeling
 Bayes' rule,Bayes' Rule
 BAYES STATISTICAL BEHAVIOR,Bayes Statistical Behavior
-Bayesian Active Learning,Bayesian Active Learning
 Bayesian decision-based neural networks,Bayesian Decision-Based Neural Networks
 Bayesian filter,Bayesian Filter
 Bayesian functionals,Bayesian Functionals
 Bayesian generalized kernel models,Bayesian Generalized Kernel Models
 Bayesian generalized linear models,Bayesian Generalized Linear Models
 Bayesian inference,Bayesian Inference
-Bayesian Logistic Regression,Bayesian Logistic Regression
 Bayesian methods,Bayesian Methods
-Bayesian Network,Bayesian Network
 Bayesian network,Bayesian Network
 BAYESIAN NETWORKS,Bayesian Network
 Bayesian Networks,Bayesian Network
@@ -896,9 +720,7 @@ Bayesian networks,Bayesian Network
 BAYESIAN PCA,Bayesian PCA
 Bayesian statistics,Bayesian Statistics
 BAYESIAN-ANALYSIS,Bayesian-Analysis
-BDRW,BDRW
 BEAM search,Beam Search
-Beam Search,Beam Search
 beam search,Beam Search
 BEARINGS,Bearings
 beautification,Beautification
@@ -919,12 +741,10 @@ Belief measures,Belief Measures
 BELIEF-PROPAGATION,Belief Propagation
 Bench marking,Bench Marking
 BENCHMARK,Benchmark
-Benchmark,Benchmark
 BENCHMARKING,Benchmark
 Benchmarking,Benchmark
 benchmarking,Benchmark
 Benchmark corpora,Benchmark Corpora
-Benchmark Database,Benchmark Database
 Benchmark database,Benchmark Database
 Benchmark dataset,Benchmark Dataset
 Benchmark evaluation,Benchmark Evaluation
@@ -934,19 +754,13 @@ Benchmark testing,Benchmark Testing
 Bender dataset,Bender Dataset
 BENEFITS,Benefits
 BENGALI,Bengali
-Bengali,Bengali
 Bengali compound characters,Bengali Compound Characters
-Bengali Handwritten Character Recognition,Bengali Handwritten Character Recognition
 bengali handwritten character recognition,Bengali Handwritten Character Recognition
 Bengali numerals,Bengali Numerals
-Bengali OCR,Bengali OCR
-Bengali Script Recognition,Bengali Script Recognition
 Bengali word recognition,Bengali Word Recognition
 Bentham dataset,Bentham Dataset
 Bernoulli HMM,Bernoulli HMMs
-Bernoulli HMMs,Bernoulli HMMs
 Bernoulli mixture,Bernoulli Mixtures
-Bernoulli Mixtures,Bernoulli Mixtures
 Beta elliptic model,Beta Elliptic Model
 Beta impulse,Beta Impulse
 beta velocity modeling,Beta Velocity Modeling
@@ -959,37 +773,25 @@ Beta-elliptic Parameters,Beta-Elliptic Parameters
 Beta-elliptical representation,Beta-Elliptical Representation
 Bethe free energy,Bethe Free Energy
 Bezier curves,Bezier Curves
-Bezier Points,Bezier Points
-BGRU,BGRU
 Bhattacharyya distance,Bhattacharyya Distance
 bias removal,Bias Removal
 BIASES,Biases
-Bibliographies,Bibliographies
-Bibliometrics,Bibliometrics
-BIC,BIC
 bi-character recognition,Bi-Character Recognition
 Bidimensional languages,Bidimensional Languages
 Bi-dimensional structured document interpretation,Bidimensional Structured Document Interpretation
-Bidirectional,Bidirectional
 bidirectional,Bidirectional
 bidirectional gated recurrent unit,Bidirectional Gated Recurrent Unit
-Bidirectional Gated Recurrent Units,Bidirectional Gated Recurrent Units
-Bidirectional Hierarchical Neural Networks,Bidirectional Hierarchical Neural Networks
 Bi-directional inertia-Trajectory translation,Bidirectional Inertia-Trajectory Translation
 BIFURCATIONS,Bifurcations
 BIG,Big
-Big Data,Big Data
 Big data,Big Data
 big data,Big Data
 big data education,Big Data Education
-Bigram,Bigram
 bigram frequency,Bigram Frequency
 bigram statistics,Bigram Statistics
 Big-step semantics,Big-Step Semantics
 bilateral filter,Bilateral Filter
 bi-level thresholding,Bi-Level Thresholding
-Bilingual,Bilingual
-Bilingual Student Identification System,Bilingual Student Identification System
 bilingualism,Bilingualism
 bidirectional long short-term memory,Bi-LSTM
 bi-directional long short-term memory (BLSTM),Bi-LSTM
@@ -1005,14 +807,10 @@ BLSTM NN,Bi-LSTM
 BLSTM-NN,Bi-LSTM
 BLSTM/CTC,Bi-LSTM/CTC
 BLSTM-CTC,Bi-LSTM/CTC
-BIM,BIM
 bimanual interaction,Bimanual Interaction
 bi-modal user interface,Bi-Modal User Interface
 BINARIZATION,Binarization
-Binarization,Binarization
 binarization,Binarization
-Binarization Text Line,Binarization Text Line
-Binary Classification,Binary Classification
 Binary data,Binary Data
 Binary document image processing,Binary Document Image Processing
 binary image,Binary Image
@@ -1020,14 +818,12 @@ BINARY PATTERNS,Binary Patterns
 Binary search,Binary Search
 BINARY SEARCH TREES,Binary Search Trees
 binary similarity,Binary Similarity
-Binary SVM,Binary SVM
 binary SVM Multi-class SVM,Binary SVM Multi-class SVM
 binary weights,Binary Weights
 binding,Binding
 Biodiversity heritage,Biodiversity Heritage
 bio-inspired optimal zoning,Bio-Inspired Optimal Zoning
 biological collections,Biological Collections
-Biologically,Biologically
 biometric applications,Biometric Applications
 BIOMETRIC AUTHENTICATION,Biometric Authentication
 Biometric authentication,Biometric Authentication
@@ -1040,20 +836,14 @@ biometric method,Biometric Method
 Biometric PIN identification,Biometric Pin Identification
 Biometric recognition,Biometric Recognition
 biometric recognition,Biometric Recognition
-Biometric Smart Pen BiSP (R),Biometric Smart Pen BiSP (R)
 Biometric system,Biometric Systems
 Biometric systems,Biometric Systems
 biometric systems,Biometric Systems
 Biometric,Biometrics
 BIOMETRICS,Biometrics
-Biometrics,Biometrics
 biometrics,Biometrics
-Biometrics Ideal Test,Biometrics Ideal Test
 biometrics of behavior,Biometrics Of Behavior
 biometrics-code converters,Biometrics-Code Converters
-Biometry,Biometry
-Biopsy Protocol,Biopsy Protocol
-BiosecurID,BiosecurID
 BiosecurID signature dataset,BiosecurID Signature Dataset
 biosignal analysis,Biosignal Analysis
 biosignal processing,Biosignal Processing
@@ -1061,7 +851,6 @@ Bipartite graph matching,Bipartite Graph Matching
 Bipartite weighted matching,Bipartite Weighted Matching
 bi-script,Bi-Script
 bisimulation,Bisimulation
-BKS,BKS
 black board model,Black Board Model
 black letter,Black Letter
 BLACKBOARD SYSTEM,Blackboard System
@@ -1075,7 +864,6 @@ BLOCK SEGMENTATION,Block Segmentation
 Block-level Transform,Block-Level Transform
 BLOCKS,Blocks
 block-wise mean-computed fuzzy based binarization,Block-Wise Mean-Computed Fuzzy Based Binarization
-Blogs,Blogs
 BLOOD-PRESSURE,Blood-Pressure
 BOLGER,Bolger
 Boltzmann machine,Boltzmann Machine
@@ -1085,17 +873,13 @@ books of hours,Book Of Hours
 BOOK,Books
 BOOKS,Books
 Boolean algebra,Boolean Algebra
-Boosting,Boosting
 boosting,Boosting
 Boosting feature selection,Boosting Feature Selection
 boosting feature selection,Boosting Feature Selection
 BoostMap,Boostmap
-Bootstrap,Bootstrap
 bootstrap,Bootstrap
 Bootstrap aggregating,Bootstrap Aggregating
-Bootstrapping,Bootstrapping
 bootstrapping',Bootstrapping
-Bopomofo,Bopomofo
 Borda count,Borda Count
 border linking,Border Linking
 Bot detection,Bot Detection
@@ -1106,12 +890,10 @@ Bounding box,Bounding Box
 bounding box,Bounding Box
 box method,Box Method
 boxed rearrangement,Boxed Rearrangement
-BP Algorithm,BP Algorithm
 BP neural network,BP Neural Network
 BP neuralnetwork,BP Neural Network
 BPN,BP Neural Network
 Bradley's method,Bradley's Method
-Brahmi,Brahmi
 Braille book,Braille Book
 BRAIN,Brain
 brain hypoxia,Brain Hypoxia
@@ -1130,13 +912,11 @@ broken character recognition,Broken Character Recognition
 broken character strokes,Broken Character Strokes
 BROKEN CHARACTERS,Broken Characters
 BRUSH MODEL,Brush Model
-BSIF,BSIF
 B-Spline curve,B-Spline Curve
 built-in effect,Built-In Effect
 Built-in functions,Built-In Functions
 BURNOUT,Burnout
 business documents,Business Documents
-Business Intelligence,Business Intelligence
 Business Process Model and Notation (BPMN),Business Process Model And Notation
 busy zone,Busy Zone
 by-example,By-Example
@@ -1144,12 +924,8 @@ BYPASS,Bypass
 Byte Pair Encoding (BPE),Byte Pair Encoding
 C plus plus,C++
 C2 features,C2 Features
-Caffe,Caffe
-CAL,CAL
 CALCIUM,Calcium
-Calculational Method,Calculational Method
 calligraphiy,Calligraphy
-Calligraphy,Calligraphy
 CALM,Calm
 camera based recognition,Camera Based Recognition
 camera image,Camera Image
@@ -1166,7 +942,6 @@ candidate lattice,Candidate Lattice
 candidate region extraction,Candidate Region Extraction
 CANDIDATE SELECTION,Candidate Selection
 candidate selection,Candidate Selection
-Canny,Canny
 canonical correlation analysis,Canonical Correlation Analysis
 canonical correlation analysis (CCA),Canonical Correlation Analysis
 CCA,Canonical Correlation Analysis
@@ -1179,18 +954,14 @@ CANT,Cant
 CAPACITY THEORY,Capacity Theory
 CAPH programming language,CAPH Programming Language
 CapsNet,Capsule Network
-Capsule Network,Capsule Network
 CAPTCHA,Captcha
 CAPTCHAs,Captcha
 CAPTCHA Solving,Captcha Solving
 Caption text recognition,Caption Text Recognition
-Captioning,Captioning
 capture-based distortions,Capture-Based Distortions
 CAR,Car
-Car Number Plate Reader,Car Number Plate Reader
 CARDIAC RISK,Cardiac Risk
 CART,Cart
-Cascade,Cascade
 cascade classifier,Cascade Classifier
 Cascade PCA-SVMNet,Cascade PCA-SVMtNet
 Cascade rejection,Cascade Rejection
@@ -1203,17 +974,11 @@ case studies,Case Studies
 Case study,Case Study
 CASE tools,Case Tools
 case-based reasoning,Case-Based Reasoning
-CASIA Offline dataset,CASIA Offline dataset
-CASIA-HWDB/OLHWDB database,CASIA-HWDB/OLHWDB database
 CASIC,Casic
 CATALOG,Catalog
 Categories-based language model,Categories-Based Language Model
 categorization,Categorization
-CBAM,CBAM
-CBIR,CBIR
 CBM writing,CBM Writing
-CCITT Group 3 Group 4,CCITT Group 3 Group 4
-CDBN,CDBN
 CEDAR-FOX,Cedar-Fox
 CELLS,Cells
 cellular automata,Cellular Automata
@@ -1231,38 +996,30 @@ Centroidal method,Centroidal Method
 CEREBRAL-ARTERY INFARCTION,Cerebral-Artery Infarction
 cg-based circle,Cg-Based Circle
 CHAIN,Chain
-Chain Code,Chain Code
 Chain code,Chain Code
 chain code,Chain Code
 chaincode,Chain Code
-Chain Code Features,Chain Code Features
 Chain code histogram,Chain Code Histogram
 chain code histogram,Chain Code Histogram
 CHAIN GRAPH,Chain Graph
 chain-coding,Chain-Coding
 CHAINS,Chains
 CHALLENGE,Challenge
-Challenge,Challenge
 challenge response protocol,Challenge Response Protocol
 challenging field,Challenging Field
-Chamfer Distance,Chamfer Distance
 Chamfer distance transform,Chamfer Distance Transform
-Channel State Information,Channel State Information
 channel state information,Channel State Information
 Channel state information (CSI),Channel State Information
 chaotic map,Chaotic Map
 CHARACTER,Character
-Character,Character
 character,Character
 Character and hull recognition,Character And Hull Recognition
 character bi-gram model,Character Bi-Gram Model
 character block layout variance,Character Block Layout Variance
-Character Classification,Character Classification
 Character classification,Character Classification
 character classification,Character Classification
 character classifier,Character Classifier
 character confusion,Character Confusion
-Character Decomposition,Character Decomposition
 CHARACTER DESCRIPTION,Character Description
 Character detection,Character Detection
 character detection and recognition,Character Detection And Recognition
@@ -1274,15 +1031,12 @@ character extraction,Character Extraction
 character feature extraction,Character Feature Extraction
 character fitness,Character Fitness
 CHARACTER GRAPH MODEL,Character Graph Model
-Character Identification,Character Identification
 character image database,Character Image Database
-Character Image Processing,Character Image Processing
 Character intensity code (CIC),Character Intensity Code
 Character level,Character Level
 Character line,Character Line
 character line,Character Line
 character location,Character Location
-Character Modeling,Character Modeling
 character models,Character Models
 Character normalization,Character Normalization
 character overlapping,Character Overlapping
@@ -1291,7 +1045,6 @@ character overlapping borders,Character Overlapping Borders
 Character recogniiton,Character Recognition
 Character Recognitio,Character Recognition
 CHARACTER RECOGNITION,Character Recognition
-Character Recognition,Character Recognition
 Character recognition,Character Recognition
 character recognition,Character Recognition
 Character Recognition (CR),Character Recognition
@@ -1310,7 +1063,6 @@ character restoration,Character Restoration
 Character retrieval,Character Retrieval
 Character rotation,Character Rotation
 CHARACTER SEGMENTATION,Character Segmentation
-Character Segmentation,Character Segmentation
 Character segmentation,Character Segmentation
 character segmentation,Character Segmentation
 Characters segmentation,Character Segmentation
@@ -1336,11 +1088,8 @@ characteres,Characters
 CHARACTERS,Characters
 characters,Characters
 character-synchronous dynamic search,Character-Synchronous Dynamic Search
-Chars74K,Chars74K
 chatroom abbreviations,Chatroom Abbreviations
-Chebyshev,Chebyshev
 Chebyshev moments (CM),Chebyshev Moments
-Check,Check
 check amount recognition,Check Amount Recognition
 CHECK ANALYSIS,Check Analysis
 check image processing,Check Image Processing
@@ -1350,12 +1099,10 @@ cheque reader,Check Reader
 Check recognition,Check Recognition
 check recognition,Check Recognition
 cheque recognition,Check Recognition
-Checkbax Recognition,Checkbax Recognition
 chemical batch processes,Chemical Batch Processes
 Chemical Reaction Optimization algorithm,Chemical Reaction Optimization Algorithm
 Chemical structure recognition,Chemical Structure Recognition
 CHEMOTHERAPY,Chemotherapy
-Cherry,Cherry
 chess moves digitization,Chess Moves Digitization
 Chess scoresheet recognition,Chess Scoresheet Recognition
 chess scoresheet recognition,Chess Scoresheet Recognition
@@ -1364,11 +1111,9 @@ Chi-square distance,Chi Square Distance
 CHILD DYSLEXICS,Child Dyslexics
 Child handwriting recognition,Child Handwriting Recognition
 CHILDREN,Children
-Children,Children
 children,Children
 Child-robot interaction,Child-Robot Interaction
 CHINESE,Chinese
-Chinese,Chinese
 Chinese character decomposition,Chinese Character Decomposition
 Chinese character processing,Chinese Character Processing
 CHINESE CHARACTER RECOGNITION,Chinese Character Recognition
@@ -1390,7 +1135,6 @@ Chinese handwriting,Chinese Handwriting
 Chinese handwriting education,Chinese Handwriting Education
 Chinese handwriting error detection,Chinese Handwriting Error Detection
 Chinese handwriting normalization,Chinese Handwriting Normalization
-Chinese Handwriting Recognition,Chinese Handwriting Recognition
 Chinese handwriting recognition,Chinese Handwriting Recognition
 Chinese handwriting recognition competition,Chinese Handwriting Recognition Competition
 Chinese handwriting writer recognition,Chinese Handwriting Writer Recognition
@@ -1398,9 +1142,7 @@ Chinese handwritten character recognition,Chinese Handwritten Character Recognit
 Chinese handwritten font,Chinese Handwritten Font
 Chinese historical image,Chinese Historical Image
 Chinese input,Chinese Input
-Chinese Legal Amount,Chinese Legal Amount
 Chinese legal amount,Chinese Legal Amount
-Chinese OCR,Chinese OCR
 Chinese script,Chinese Script
 Chinese strokes,Chinese Strokes
 CHINESE TEXT,Chinese Text
@@ -1410,9 +1152,7 @@ Choquet integral,Choquet Integral
 Chord length,Chord Length
 CHROMOSOME-6,Chromosome-6
 chronic disease,Chronic Disease
-Chu Nom Characters,Chu Nom Characters
 chu nom characters,Chu Nom Characters
-CIFAR,CIFAR
 Circuit component recognition,Circuit Component Recognition
 CIRCUITS,Circuits
 circular quadrant mass distribution,Circular Quadrant Mass Distribution
@@ -1432,13 +1172,9 @@ Class-dependent and class-independent,Class-Dependent And Class-Independent
 class-dependent feature combination,Class-Dependent Feature Combination
 classfier combination,Classfier Combination
 class-guided prediction,Class-Guided Prediction
-Classifiability,Classifiability
-Classifiaction,Classifiaction
 CLASSIFICATION,Classification
-Classification,Classification
 classification,Classification
 classification accuracy,Classification Accuracy
-Classification Algorithms,Classification Algorithms
 classification error,Classification Error
 Classification methods,Classification Methods
 Classification Model,Classification Models
@@ -1446,21 +1182,17 @@ Classification models,Classification Models
 Classification of caption text,Classification Of Caption Text
 classification of scene text,Classification Of Scene Text
 Classification performance,Classification Performance
-Classification Reliability,Classification Reliability
 classification speed,Classification Speed
 Classification techniques,Classification Techniques
 classification techniques,Classification Techniques
 Classification trees,Classification Trees
 CLASSIFIER,Classifier
-Classifier,Classifier
 classifier collaboration,Classifier Collaboration
 CLASSIFIER COMBINATION,Classifier Combination
-Classifier Combination,Classifier Combination
 Classifier combination,Classifier Combination
 classifier combination,Classifier Combination
 classifier combining,Classifier Combination
 classifier ensemble methods,Classifier Ensemble Methods
-Classifier Ensembles,Classifier Ensembles
 CLASSIFIER FUSION,Classifier Fusion
 Classifier fusion,Classifier Fusion
 classifier fusion,Classifier Fusion
@@ -1471,7 +1203,6 @@ classifier similarity,Classifier Similarity
 classifier subset selection,Classifier Subset Selection
 classifier training,Classifier Training
 CLASSIFIERS,Classifiers
-Classifiers,Classifiers
 classifiers,Classifiers
 CLASSIFIERS COMBINATION,Classifiers Combination
 classifiers combination,Classifiers Combination
@@ -1489,9 +1220,7 @@ clinical data exchange,Clinical Data Exchange
 clinical decision support,Clinical Decision Support
 Clinical de-identification,Clinical De-Identification
 CLINICAL TRIAL,Clinical Trial
-Clock Drawing Test,Clock Drawing Test
 Clock Drawing Test (CDT),Clock Drawing Test
-Clonclas,Clonclas
 CLONING TEMPLATE,Cloning Template
 closed character detection,Closed Character Detection
 Closure of Fuzzy Galois connections,Closure Of Fuzzy Galois Connections
@@ -1505,28 +1234,20 @@ CLUSTER NEURAL-NETWORK,Cluster Neural-Network
 cluster prediction,Cluster Prediction
 cluster resolution,Cluster Resolution
 CLUSTERING,Clustering
-Clustering,Clustering
 clustering,Clustering
 clustering comparison,Clustering Comparison
 clustering evaluation,Clustering Evaluation
 CLUSTERING PROBLEM,Clustering Problem
 clustering-based discriminant analysis,Clustering-Based Discriminant Analysis
 CLUSTERS,Clusters
-CMA-MOHR,CMA-MOHR
-CMARTdb,CMARTdb
-CMATERdb,CMATERdb
 CMATERdb dataset,CMATERdb
-CMI,CMI
 CMOS IMPLEMENTATION,Cmos Implementation
 cascade neural network,CNN
 Cascaded CNN,CNN
-CNN,CNN
 cnn,CNN
 CNN model,CNN
 CNNs,CNN
 CNN Universal Machine (CNN-UM),CNN Universal Machine
-CNN-BLSTM,CNN-BLSTM
-CNN-RNN Hybrid Network,CNN-RNN Hybrid Network
 CNN-RNN network,CNN-RNN Network
 CNN-SVM CLASSIFIER,CNN-SVM Classifier
 Co-adaptation,Co-Adaptation
@@ -1544,12 +1265,10 @@ CODEBOOK,Codebook
 codebook,Codebook
 codebook learning,Codebook Learning
 Codebook of graphemes,Codebook Of Graphemes
-Codes,Codes
 codeword,Codeword
 coding particle,Coding Particle
 coefficient of variation,Coefficient Of Variation
 cognition and perception,Cognition And Perception
-Cognitive,Cognitive
 cognitive,Cognitive
 cognitive control,Cognitive Control
 Cognitive effort,Cognitive Effort
@@ -1558,11 +1277,8 @@ cognitive impairment diagnosis,Cognitive Impairment Diagnosis
 cognitive load,Cognitive Load
 COGNITIVE NEUROSCIENCE,Cognitive Neuroscience
 Cognitive tutors,Cognitive Tutors
-Cogntive Assessment,Cogntive Assessment
 COHERENCE FACTOR,Coherence Factor
-Cohort,Cohort
 collaborative filtering,Collaborative Filtering
-Collaborative Interaction,Collaborative Interaction
 Collaborative learning,Collaborative Learning
 COLLABORATIVE REPRESENTATION,Collaborative Representation
 Collaborative transcription,Collaborative Transcription
@@ -1572,15 +1288,12 @@ COLLOCATIONS,Collocations
 Colloquial language recognition,Colloquial Language Recognition
 COLOR,Color
 Color clustering,Color Clustering
-Color Control,Color Control
 Color document image,Color Document Image
 Color feature,Color Feature
 COLOR IMAGE,Color Image
-Color Sagging,Color Sagging
 Color spaces,Color Spaces
 COLOR-GRAPHEMIC SYNAESTHESIA,Color-Graphemic Synaesthesia
 COMBINATION,Combination
-Combination,Combination
 combination,Combination
 Combination method,Combination Methods
 COMBINATION METHODS,Combination Methods
@@ -1602,12 +1315,10 @@ combining classifiers,Combining Classifiers
 combining methods,Combining Methods
 COMBINING MULTIPLE CLASSIFIERS,Combining Multiple Classifiers
 combining on-line and off-line features,Combining On-Line And Off-Line Features
-Combining Rules,Combining Rules
 combining strategy,Combining Strategy
 COMENIA SCRIPT,Comenia Script
 comics analysis,Comics Analysis
 comics image analysis,Comics Image Analysis
-Committee,Committee
 committee classifier,Committee Classifier
 COMMITTEE-MACHINE,Committee-Machine
 COMMUNICATION,Communication
@@ -1616,28 +1327,21 @@ communication protocols,Communication Protocols
 compact classifier,Compact Classifier
 comparison of parsing algorithms,Comparison Of Parsing Algorithms
 COMPETITION,Competition
-Competition,Competition
 competition,Competition
-Competitions,Competitions
-Competitive Learning,Competitive Learning
 competitive learning algorithm,Competitive Learning Algorithm
 complementary approaches and techniques,Complementary Approaches And Techniques
 Complementary features,Complementary Features
-Complete Character Set,Complete Character Set
 complete working system,Complete Working System
 complex characters,Complex Characters
 complex document information processing,Complex Document Information Processing
 complex document processing,Complex Document Processing
 complex scene,Complex Scene
 complex shapes,Complex Shapes
-Complex Temporal Pattern,Complex Temporal Pattern
 complex wavelet transform,Complex Wavelet Transform
 COMPLEXITY,Complexity
-Complexity,Complexity
 complexity and memory space,Complexity And Memory Space
 Complexity reduction,Complexity Reduction
 complications,Complications
-Component,Component
 component,Component
 COMPONENT ANALYSIS,Component Analysis
 component clustering,Component Clustering
@@ -1653,9 +1357,7 @@ Compound character recognition,Compound Character Recognition
 COMPOUND CHARACTER-RECOGNITION,Compound Character Recognition
 compound character,Compound Characters
 compound characters,Compound Characters
-Compound Distance,Compound Distance
 compound fault separation,Compound Fault Separation
-Compounds,Compounds
 COMPREHENSION,Comprehension
 COMPREHENSIVE SURVEY,Comprehensive Survey
 compressed data,Compressed Data
@@ -1665,7 +1367,6 @@ compressed image,Compressed Image
 Compressed sensing,Compressed Sensing
 Compressed stream,Compressed Stream
 COMPRESSION,Compression
-Compression,Compression
 compression,Compression
 Compression algorithms,Compression Algorithms
 compression ratio,Compression Ratio
@@ -1673,7 +1374,6 @@ compressive sensing,Compressive Sensing
 COMPUTATION,Computation
 computational complexity,Computational Complexity
 computational electrochemistry,Computational Electrochemistry
-Computational Forensics,Computational Forensics
 computational forensics,Computational Forensics
 Computational generation model,Computational Generation Model
 computational geometry,Computational Geometry
@@ -1681,7 +1381,6 @@ computational linguistics,Computational Linguistics
 Computational modeling,Computational Modeling
 computational neuroscience,Computational Neuroscience
 Computer aided assessment,Computer Aided Assessment
-Computer Aided Detection,Computer Aided Detection
 Computer and information processing,Computer And Information Processing
 Computer application,Computer Application
 computer application,Computer Application
@@ -1697,12 +1396,10 @@ computer keyboard,Computer Keyboard
 computer networks,Computer Networks
 COMPUTER RECOGNITION,Computer Recognition
 COMPUTER SCIENCE,Computer Science
-Computer Science Education,Computer Science Education
 Computer security,Computer Security
 computer supported collaborative work (CSCW),Computer Supported Collaborative Work
 Computer viruses,Computer Viruses
 COMPUTER VISION,Computer Vision
-Computer Vision,Computer Vision
 Computer vision,Computer Vision
 computer vision,Computer Vision
 computer vision tasks,Computer Vision Tasks
@@ -1723,7 +1420,6 @@ computerized data processing,Computerized Data Processing
 Computerized detection tool,Computerized Detection Tool
 Computerized measures,Computerized Measures
 COMPUTERS,Computers
-Computers,Computers
 computers,Computers
 "computers, diagnostic aid","Computers, Diagnostic Aid"
 "computers, educational aid","Computers, Educational Aid"
@@ -1733,17 +1429,14 @@ COMPUTING COMPLEXITY,Computing Complexity
 Computing education,Computing Education
 computing time,Computing Time
 concavity features,Concavity Features
-Concentration,Concentration
 CONCRETE,Concrete
 concrete structures,Concrete Structures
 Conditional AutoEncoder,Conditional Autoencoder
 Conditional Random Field,Conditional Random Fields
 Conditional Random Field(CRF),Conditional Random Fields
-Conditional Random Fields,Conditional Random Fields
 Conditional Random fields,Conditional Random Fields
 Conditional random fields,Conditional Random Fields
 conditional random fields,Conditional Random Fields
-Conducting,Conducting
 CONFIDENCE,Confidence
 Confidences,Confidence
 confidence analysis,Confidence Analysis
@@ -1753,7 +1446,6 @@ confidence evaluation,Confidence Evaluation
 Confidence learning,Confidence Learning
 confidence level,Confidence Level
 CONFIDENCE MEASURES,Confidence Measures
-Confidence Measures,Confidence Measures
 Confidence measures,Confidence Measures
 confidence measures,Confidence Measures
 Confidence score,Confidence Score
@@ -1767,7 +1459,6 @@ CONFLICT,Conflict
 conflict management,Conflict Management
 conflict resolution,Conflict Resolution
 Confusing pair,Confusing Pair
-Confusion Matrix,Confusion Matrix
 Confusion matrix,Confusion Matrix
 confusion matrix,Confusion Matrix
 confusion model,Confusion Model
@@ -1775,21 +1466,14 @@ CONFUSION NETWORKS,Confusion Networks
 confusion networks,Confusion Networks
 Confusion Networks combination,Confusion Networks Combination
 confusion networks combination,Confusion Networks Combination
-Confusion Pairs,Confusion Pairs
 congealing,Congealing
-Connected Component,Connected Component
 Connected component,Connected Component
-Connected Component Analysis,Connected Component Analysis
 Connected component analysis,Connected Component Analysis
 Connected Component Analysis.,Connected Component Analysis
 connected components analysis,Connected Component Analysis
 connected component grouping,Connected Component Grouping
-Connected Component Labeling,Connected Component Labeling
 connected component labeling,Connected Component Labeling
-Connected Components,Connected Components
 connected components,Connected Components
-Connected Domain,Connected Domain
-Connected Pixels Labeling,Connected Pixels Labeling
 Connected segments,Connected Segments
 CONNECTED WORD RECOGNITION,Connected Word Recognition
 connected writing,Connected Writing
@@ -1798,10 +1482,8 @@ CONNECTION,Connection
 connection lines,Connection Lines
 CONNECTION MACHINE,Connection Machine
 connection points,Connection Points
-Connectionism,Connectionism
 Connectionist automatic speech recognition,Connectionist Automatic Speech Recognition
 connectionist systems,Connectionist Systems
-Connectionist Temporal Classification,Connectionist Temporal Classification
 Connectionist temporal classification,Connectionist Temporal Classification
 connectionist temporal classification,Connectionist Temporal Classification
 Connectionist temporal classification (CTC),Connectionist Temporal Classification
@@ -1813,8 +1495,6 @@ Connectivity strength function,Connectivity Strength Function
 Connectivity strength parameter,Connectivity Strength Parameter
 CONSISTENCY,Consistency
 Constellation model,Constellation Model
-Constrained Character Recognition,Constrained Character Recognition
-Constrained Handwriting Recognition,Constrained Handwriting Recognition
 Constrained Viterbi search,Constrained Viterbi Search
 constraint decoding,Constraint Decoding
 CONSTRAINT SATISFACTION,Constraint Satisfaction
@@ -1825,7 +1505,6 @@ Construction Method for Selecting Effective Hidden Nodes (CMSEHN),Construction M
 constructive induction,Constructive Induction
 consumer electronics world,Consumer Electronics World
 consumer-grade camera images,Consumer-Grade Camera Images
-Contact Center,Contact Center
 Contact image Sensor (CIS),Contact Image Sensor
 content and style disentanglement,Content And Style Disentanglement
 content based retrieval,Content Based Retrieval
@@ -1839,7 +1518,6 @@ content-based image retrieval (CBIR),Content-Based Image Retrieval
 Contex-aware services,Contex-Aware Services
 CONTEXT,Context
 context,Context
-Context Dependent Modeling,Context Dependent Modeling
 Context free grammar,Context Free Grammar
 context reduction,Context Reduction
 Context variables,Context Variables
@@ -1874,7 +1552,6 @@ CONTINUOUS SPEECH RECOGNITION,Continuous Speech Recognition
 continuous strokes text,Continuous Strokes Text
 Continuous trajectory segment,Continuous Trajectory Segment
 CONTOUR,Contour
-Contour,Contour
 contour,Contour
 Contour alignment,Contour Alignment
 Contour analysis,Contour Analysis
@@ -1884,11 +1561,9 @@ Contour detection,Contour Detection
 Contour feature,Contour Feature
 contour following,Contour Following
 contour information,Contour Information
-Contour Tracing,Contour Tracing
 contour-hinge feature,Contour-Hinge Feature
 Contourlet transform,Contourlet Transform
 contourlet transform,Contourlet Transform
-Contrast,Contrast
 Contrast based adaptive binarization,Contrast Based Adaptive Binarization
 contrast image,Contrast Image
 contrastive divergence,Contrastive Divergence
@@ -1898,24 +1573,16 @@ control of implicit segmentation,Control Of Implicit Segmentation
 control of physical systems,Control Of Physical Systems
 CONTROLLER,Controller
 CONTROL-SYSTEMS,Control-Systems
-Convenience Photos,Convenience Photos
 CONVERGENCE,Convergence
 convex hull,Convex Hull
 Convexity curve,Convexity Curve
-ConvLSTM,ConvLSTM
 convNet-based feature extraction,ConvNet-Based Feature Extraction
-Convolution,Convolution
 convolution,Convolution
 Convolution layer,Convolution Layer
-Convolution Model,Convolution Model
 ConvNet,Convolution Neural Network
-Convolutional,Convolutional
-Convolutional Autoencoder,Convolutional Autoencoder
 convolutional autoencoder,Convolutional Autoencoder
-Convolutional Auto-Encoder,Convolutional Auto-Encoder
 Convolutional BiLSTM network,Convolutional BiLSTM Network
 convolutional bilstm network,Convolutional BiLSTM Network
-Convolutional Deep Belief Networks,Convolutional Deep Belief Networks
 Convolutional layer,Convolutional Layers
 convolutional layers,Convolutional Layers
 Convolution Neural Network,Convolutional Neural Network
@@ -1929,7 +1596,6 @@ Convolutional Networks,Convolutional Neural Network
 convolutional networks,Convolutional Neural Network
 Convolutional Neural Netowrk (CNN),Convolutional Neural Network
 convolutional neural nets,Convolutional Neural Network
-Convolutional Neural Network,Convolutional Neural Network
 Convolutional neural Network,Convolutional Neural Network
 Convolutional neural network,Convolutional Neural Network
 convolutional neural network,Convolutional Neural Network
@@ -1951,7 +1617,6 @@ CONVOLUTIONAL NEURAL-NETWORK,Convolutional Neural Network
 CONVOLUTIONAL NEURAL-NETWORKS,Convolutional Neural Network
 Convolutional-neural-networks,Convolutional Neural Network
 Convolutional Neural Network (CNN) accelerator,Convolutional Neural Network Accelerator
-Convolutional Neural Network Handwritten Numeral Recognition,Convolutional Neural Network Handwritten Numeral Recognition
 Convolutional neural network shape models,Convolutional Neural Network Shape Models
 convolutional neural network-based transfer learning architectures,Convolutional Neural Network-Based Transfer Learning Architectures
 Convolutional prototype network,Convolutional Prototype Network
@@ -1965,7 +1630,6 @@ Co-occurrence features,Co-Occurrence Features
 co-occurrence matrix,Co-Occurrence Matrix
 cooperation,Cooperation
 COOPERATION OF CLASSIFIERS,Cooperation Of Classifiers
-Cooperative Morphological-Guided Recognition,Cooperative Morphological-Guided Recognition
 coordinate frames,Coordinate Frames
 coordinate processing,Coordinate Processing
 COORDINATION,Coordination
@@ -1975,7 +1639,6 @@ corner detector,Corner Detector
 Coronal mass ejections,Coronal Mass Ejections
 coronavirus,Coronavirus
 CORPUS,Corpus
-Corpus,Corpus
 corpus,Corpus
 Corpus annotation,Corpus Annotation
 Corpus creation,Corpus Creation
@@ -1992,32 +1655,23 @@ Cortical algorithms,Cortical Algorithms
 Cortical columns,Cortical Columns
 CORTICAL MIDLINE STRUCTURES,Cortical Midline Structures
 cortical representation,Cortical Representation
-Cosine Similarity,Cosine Similarity
 cost matrix optimization,Cost Matrix Optimization
 cost-sensitive learning,Cost-Sensitive Learning
-Co-Training,Co-Training
 Co-training,Co-Training
 counter propagation neural networks,Counter Propagation Neural Networks
 counter-propagation neural networks,Counter Propagation Neural Networks
 COURTESY AMOUNT,Courtesy Amount
 courtesy amount,Courtesy Amount
-Courtesy Amount Recognition,Courtesy Amount Recognition
 Courtesy amount recognition,Courtesy Amount Recognition
 courtesy amount recognition,Courtesy Amount Recognition
 Covariance modeling,Covariance Modeling
 cover-function,Cover-Function
-COVID-19,COVID-19
-CPOE,CPOE
 crack detection,Crack Detection
 crack extraction,Crack Extraction
 Crack identification,Crack Identification
 crease removal,Crease Removal
-CRF,CRF
-CRF/HMM,CRF/HMM
-Criminal Investigation Instrument,Criminal Investigation Instrument
 Crisp possibilistic mean value,Crisp Possibilistic Mean Value
 critical regions,Critical Regions
-Cropping,Cropping
 cross validation,Cross Validation
 Cross-correlation coefficient,Cross-Correlation Coefficient
 Cross-depiction,Cross-Depiction
@@ -2030,23 +1684,16 @@ crossvalidation,Cross-Validation
 CROSS-VALIDATION,Cross-Validation
 cross-validation,Cross-Validation
 Crowding characters together,Crowding Characters Together
-Crowdsourcing,Crowdsourcing
 crowdsourcing,Crowdsourcing
 crowdsourcing framework,Crowdsourcing Framework
 crucial combination,Crucial Combination
 cryptosystem,Cryptosystem
-CSI Image,CSI Image
-CSI-Ratio,CSI-Ratio
-CSLBP,CSLBP
-CTC,CTC
 cubic B-spline,Cubic B-Spline
-CUDA,CUDA
 Cultural differences,Cultural Differences
 Cultural heritage,Cultural Heritage
 cultural heritage,Cultural Heritage
 Cumulative error vs. cost curve,Cumulative Error Vs. Cost Curve
 Cumulative Trauma Disorders (CTD),Cumulative Trauma Disorders
-Cuneiform,Cuneiform
 cuneiform,Cuneiform
 Cuneiform script,Cuneiform Script
 curriculum design,Curriculum Design
@@ -2062,7 +1709,6 @@ cursive character recognition,Cursive Character Recognition
 CURSIVE CHARACTER-RECOGNITION,Cursive Character Recognition
 CURSIVE CHARACTERS,Cursive Characters
 cursive characters,Cursive Characters
-Cursive Chinese Calligraphy,Cursive Chinese Calligraphy
 CURSIVE HANDWRITING,Cursive Handwriting
 Cursive handwriting,Cursive Handwriting
 cursive handwriting,Cursive Handwriting
@@ -2073,7 +1719,6 @@ cursive handwritten text recognition,Cursive Handwritten Text Recognition
 cursive image dataset,Cursive Image Dataset
 Cursive Malayalam characters,Cursive Malayalam Characters
 CURSIVE SCRIPT,Cursive Script
-Cursive Script,Cursive Script
 Cursive script,Cursive Script
 cursive script,Cursive Script
 cursive scripts,Cursive Script
@@ -2091,7 +1736,6 @@ cursive words,Cursive Words
 cursiveness,Cursiveness
 cursive-script segmentation,Cursive-Script Segmentation
 CURVATURE,Curvature
-Curvature,Curvature
 curvature detection,Curvature Detection
 Curvature feature,Curvature Feature
 curvature feature,Curvature Feature
@@ -2101,9 +1745,6 @@ CURVE ALIGNMENT,Curve Alignment
 curve alignment,Curve Alignment
 curve evolution,Curve Evolution
 curve fitting,Curve Fitting
-Curve Matching,Curve Matching
-Curve Modeling,Curve Modeling
-Curve Pattern Analysis,Curve Pattern Analysis
 curve similarity,Curve Similarity
 curve similarity model,Curve Similarity Model
 curve similarity transformation,Curve Similarity Transformation
@@ -2114,23 +1755,18 @@ CURVES,Curves
 custom image dataset,Custom Image Dataset
 Customizable on-line recognition systems,Customizable On-Line Recognition Systems
 CUTS,Cuts
-CVL Database,CVL Database
 cyber games,Cyber Games
 Cyber Physical System (CPS),Cyber Physical System
 cyber-physical systems,Cyber Physical System
 Cyber security,Cyber Security
 cybercrime investigation,Cybercrime Investigation
 Cylindrical shape context,Cylindrical Shape Context
-Czech,Czech
-d2 attention test,d2 attention test
 DAMAGE DETECTION,Damage Detection
 dannotation,Dannotation
-DAS methodology,DAS methodology
 data acquisition,Data Acquisition
 data algorithm,Data Algorithm
 methods: data analysis,Data Analysis
 DATA AUGMENTATION,Data Augmentation
-Data Augmentation,Data Augmentation
 Data augmentation,Data Augmentation
 data augmentation,Data Augmentation
 data augmentation (DA),Data Augmentation
@@ -2143,17 +1779,12 @@ data emphasizing,Data Emphasizing
 data entry,Data Entry
 data extraction,Data Extraction
 data flow analysis,Data Flow Analysis
-Data Form,Data Form
 data format,Data Format
-Data Fusion,Data Fusion
 Data fusion,Data Fusion
 data fusion,Data Fusion
 data imbalance,Data Imbalance
 data input system,Data Input System
-Data Integration,Data Integration
-Data Link Layer,Data Link Layer
 data management,Data Management
-Data Mining,Data Mining
 Data mining,Data Mining
 data mining,Data Mining
 Data mining of Arabic documents,Data Mining Of Arabic Documents
@@ -2163,26 +1794,17 @@ data parallelization,Data Parallelization
 Data preprocessing,Data Preprocessing
 DATA PROCESSING,Data Processing
 data quality,Data Quality
-Data Quality Assurance Program,Data Quality Assurance Program
-Data Representation,Data Representation
 data science,Data Science
-Data Security,Data Security
 Data set creation South Indian scripts,Data Set Creation South Indian Scripts
 data synchronization,Data Synchronization
-Data Synthesis,Data Synthesis
 Data synthesis,Data Synthesis
 data visualization,Data Visualization
-Data Warehousing,Data Warehousing
 DATABASE,Database
-Database,Database
 database,Database
 DATABASES,Database
 Databases,Database
 databases,Database
-Database (NDAHR),Database (NDAHR)
 database adaptation,Database Adaptation
-Database Design,Database Design
-database ETL9B,database ETL9B
 database generation,Database Generation
 Database of cheques,Database Of Checks
 Database of Persian Signatures,Database Of Persian Signatures
@@ -2193,35 +1815,18 @@ DATA-ENTRY,Data-Entry
 Dataflow computing,Dataflow Computing
 dataflow object detection system,Dataflow Object Detection System
 DATASET,Dataset
-Dataset,Dataset
 dataset,Dataset
 Datasets,Dataset
 datasets,Dataset
-Dataset Acquisition,Dataset Acquisition
 Dataset creation,Dataset Creation
 dataset curation,Dataset Curation
 date detection,Date Detection
-Date Recognition,Date Recognition
 Date recognition,Date Recognition
 date recognition,Date Recognition
 Date spotting,Date Spotting
 Date-based indexing,Date-Based Indexing
-DB-CREATOR,DB-CREATOR
-DBN,DBN
-DBNN,DBNN
-DBSCAN,DBSCAN
-DBScan,DBScan
-DCNN,DCNN
-DCNN Classifier,DCNN Classifier
-DCT,DCT
-DCT coefficients,DCT coefficients
-DDD,DDD
-Dead Sea Scrolls,Dead Sea Scrolls
 DEAD-SEA-SCROLLS,Dead Sea Scrolls
-Deafness,Deafness
-Debugging,Debugging
 deCasteljau algorithm,Decasteljau Algorithm
-Decimal Digits Dataset,Decimal Digits Dataset
 DECISION,Decision
 DECISION BOUNDARIES,Decision Boundaries
 DECISION COMBINATION,Decision Combination
@@ -2244,7 +1849,6 @@ DECISION-SUPPORT-SYSTEM,Decision-Support-System
 decision-tree learning,Decision-Tree Learning
 decoder,Decoder
 decoder model,Decoder Model
-Decoding,Decoding
 decoding,Decoding
 DECOMPOSITION,Decomposition
 Decomposition rules,Decomposition Rules
@@ -2255,7 +1859,6 @@ DEEP,Deep
 Deep and shallow architectures,Deep And Shallow Architectures
 deep architecture,Deep Architecture
 deep architectures,Deep Architecture
-Deep Belief Network,Deep Belief Network
 Deep belief network,Deep Belief Network
 deep belief network,Deep Belief Network
 Deep Belief Networks,Deep Belief Network
@@ -2266,7 +1869,6 @@ Deep capsule network,Deep Capsule Network
 Deep Convolution Neural Network,Deep Convolutional Neural Network
 Deep convolution neural network,Deep Convolutional Neural Network
 Deep convolutional neural,Deep Convolutional Neural Network
-Deep Convolutional Neural Network,Deep Convolutional Neural Network
 Deep convolutional neural network,Deep Convolutional Neural Network
 deep convolutional neural network,Deep Convolutional Neural Network
 Deep Convolutional Neural Network (DCNN),Deep Convolutional Neural Network
@@ -2275,12 +1877,10 @@ Deep Convolutional Neural Networks,Deep Convolutional Neural Network
 Deep convolutional neural networks,Deep Convolutional Neural Network
 deep convolutional neural networks,Deep Convolutional Neural Network
 deep convolutional neural network-based holistic method,Deep Convolutional Neural Network-Based Holistic Method
-Deep Convolutional Recurrent Neural Network,Deep Convolutional Recurrent Neural Network
 deep feature representation extraction,Deep Feature Representation Extraction
 Deep features,Deep Features
 deep features,Deep Features
 deep features fusion,Deep Features Fusion
-Deep Learning,Deep Learning
 Deep learning,Deep Learning
 deep learning,Deep Learning
 Deep Learning (DL),Deep Learning
@@ -2292,7 +1892,6 @@ Deep learning algorithms,Deep Learning Algorithms
 deep learning approach,Deep Learning Approach
 Deep learning models,Deep Learning Models
 deep learning network,Deep Learning Neural Network
-Deep Learning Neural Network,Deep Learning Neural Network
 deep learning neural network (DLNN),Deep Learning Neural Network
 Deep learning neural Networks,Deep Learning Neural Network
 DEEP LEARNING TECHNIQUES,Deep Learning Techniques
@@ -2301,7 +1900,6 @@ deep metric learning,Deep Metric Learning
 Deep model,Deep Model
 deep model,Deep Model
 Deep networks,Deep Neural Network
-Deep Neural Network,Deep Neural Network
 Deep neural Network,Deep Neural Network
 Deep neural network,Deep Neural Network
 deep neural network,Deep Neural Network
@@ -2312,10 +1910,8 @@ Deep neural networks,Deep Neural Network
 deep neural networks,Deep Neural Network
 deep neural networks (DNN),Deep Neural Network
 Deep quad tree,Deep Quad Tree
-Deep SVM,Deep SVM
 deep template,Deep Template
 deep transfer learning,Deep Transfer Learning
-DeepFuseOSV,DeepFuseOSV
 DEFICIENCIES,Deficiencies
 DEFICIT DISORDER,Deficit Disorder
 DEFICIT HYPERACTIVITY DISORDER,Deficit Hyperactivity Disorder
@@ -2352,10 +1948,8 @@ DEMAND,Demands
 DEMANDS,Demands
 DEMENTIA,Dementia
 dementia,Dementia
-Demographic,Demographic
 Demographic data collection,Demographic Data Collection
 demonstrator,Demonstrator
-Dempster-Shafer Theory,Dempster-Shafer Theory
 Dempster-Shafer theory,Dempster-Shafer Theory
 Dempster-Shafer Theory (DST),Dempster-Shafer Theory
 DENSE,Dense
@@ -2377,26 +1971,21 @@ dependency modeling,Dependency Modeling
 DEPRESSION,Depression
 Depth first search,Depth First Search
 depthwise separable convolution neural network architecture,Depthwise Separable Convolution Neural Network Architecture
-Derivation,Derivation
 derived components,Derived Components
-Descender,Descender
 DESCENT,Descent
 DESCRIPTION LENGTH PRINCIPLE,Description Length Principle
 descriptor,Descriptors
 DESCRIPTORS,Descriptors
 DESIGN,Design
-Design,Design
 Design and simulation,Design And Simulation
 design automation,Design Automation
 design framework,Design Framework
 DESIGN OF EXPERIMENTS,Design Of Experiments
 designing neural networks,Designing Neural Networks
-Deskewing,Deskewing
 DESLANTING,Deslanting
 DESLOPING,Desloping
 DESTINATION ADDRESSES,Destination Addresses
 Detailed Assessment of Speed of Handwriting (DASH),Detailed Assessment Of Speed Of Handwriting
-Detection,Detection
 detection,Detection
 DETECTION ALGORITHM,Detection Algorithm
 Detection of alcohol intoxication,Detection Of Alcohol Intoxication
@@ -2407,7 +1996,6 @@ deterministic approach,Deterministic Approach
 Deterministic finite automaton,Deterministic Finite Automaton
 deterministic finite automaton,Deterministic Finite Automaton
 DEVANAGARI,Devanagari
-Devanagari,Devanagari
 Devanagri,Devanagari
 DEVNAGARI,Devanagari
 Devnagari and Segmentation,Devanagari And Segmentation
@@ -2417,18 +2005,13 @@ devanagari character,Devanagari Characters
 Devanagari characters,Devanagari Characters
 Devanagri Characters,Devanagari Characters
 DEVNAGARI CHARACTERS,Devanagari Characters
-Devanagari Dataset,Devanagari Dataset
 Devanagari handwriting analysis,Devanagari Handwriting Analysis
 Devnagari Handwritten Character Recognition,Devanagari Handwritten Character Recognition
 devanagari handwritten numeral recognition,Devanagari Handwritten Numeral Recognition
 Devanagari historical documents,Devanagari Historical Documents
 Devanagari language,Devanagari Language
-Devanagari Numerals,Devanagari Numerals
-Devanagari OCR,Devanagari OCR
 devanagari recognition,Devanagari Recognition
-Devanagari Script,Devanagari Script
 Devanagari script,Devanagari Script
-Devanagari Word Recognition,Devanagari Word Recognition
 Devanagari word recognition,Devanagari Word Recognition
 development of writing,Development Of Writing
 DEVELOPMENTAL COORDINATION DISORDER,Developmental Coordination Disorder
@@ -2440,53 +2023,36 @@ DEVICE,Device
 Device-free,Device-Free
 Device-free sensing,Device-Free Sensing
 DEVICES,Devices
-Devices,Devices
-DevNet,DevNet
 Dezert-Smarandache theory,Dezert-Smarandache Theory
-DFT,DFT
-DHMMs,DHMMs
 Diabetes determination,Diabetes Determination
 diabetic disease,Diabetic Disease
 Diacritic,Diacritical Marks
 diacritic marks,Diacritical Marks
-Diacritical Marks,Diacritical Marks
 diacritics,Diacritical Marks
 diacritics detection,Diacritics Detection
 DIAGNOSIS,Diagnosis
-Diagnosis,Diagnosis
 DIAGNOSTIC ENTITY,Diagnostic Entity
-Diagonal Feature,Diagonal Feature
-Diagonal Feature Extraction,Diagonal Feature Extraction
-Diagram,Diagram
 diagram,Diagram
 Diagram recognition,Diagram Recognition
 DIALOG,Dialog
-DIBCO,DIBCO
-Dictation,Dictation
 dictation,Dictation
 DICTIONARIES,Dictionaries
-Dictionaries,Dictionaries
 Dictionary,Dictionaries
 dictionary,Dictionaries
 dictionary atom,Dictionary Atom
 dictionary expansion,Dictionary Expansion
-Dictionary Learning,Dictionary Learning
 dictionary patterns,Dictionary Patterns
 DICTIONARY SEARCH,Dictionary Search
 different granularity levels,Different Granularity Levels
-Differential Evolution,Differential Evolution
 Differential evolution,Differential Evolution
 DIFFERENTIAL EVOLUTION ALGORITHM,Differential Evolution Algorithm
 differential morphology,Differential Morphology
-differential vector-KPCA,differential vector-KPCA
 DIFFERENTIAL-DIAGNOSIS,Differential-Diagnosis
 DIFFICULT,Difficulties
 DIFFICULTIES,Difficulties
 digit classification,Digit Classification
-Digit Detection,Digit Detection
 digit detection and recognition,Digit Detection And Recognition
 DIGIT RECOGNITION,Digit Recognition
-Digit Recognition,Digit Recognition
 Digit recognition,Digit Recognition
 digit recognition,Digit Recognition
 digit string,Digit String
@@ -2494,39 +2060,31 @@ Digit string recognition,Digit String Recognition
 digital archive,Digital Archive
 Digital archives,Digital Archive
 digital assistants,Digital Assistants
-Digital Corpuses,Digital Corpuses
 digital doodles,Digital Doodles
-Digital Focus Index,Digital Focus Index
 DIGITAL FORENSICS,Digital Forensics
 digit handwritings,Digital Handwriting
 digital handwriting,Digital Handwriting
 Digital heritage,Digital Heritage
 digital human model,Digital Human Model
 DIGITAL HUMANITIES,Digital Humanities
-Digital Humanities,Digital Humanities
 Digital humanities,Digital Humanities
 digital humanities,Digital Humanities
 digital image,Digital Image
 DIGITAL IMAGE PROCESSING,Digital Image Processing
-Digital Image Processing,Digital Image Processing
 Digital image processing,Digital Image Processing
 digital in-betweening,Digital In-Betweening
-Digital India,Digital India
 digital ink,Digital Ink
 digital ink search,Digital Ink Search
 Digital learning,Digital Learning
 digital libraries,Digital Libraries
 digital library,Digital Library
 Digital library infrastructure,Digital Library Infrastructure
-Digital Palaeography,Digital Palaeography
 Digital palaeography,Digital Palaeography
-Digital Pen,Digital Pen
 Digital pen,Digital Pen
 digital pen,Digital Pen
 digital pens,Digital Pen
 DIGITAL PLANAR CURVES,Digital Planar Curves
 Digital signal processing transform,Digital Signal Processing Transform
-Digital Surfaces,Digital Surfaces
 Digital tools,Digital Tools
 digital traces,Digital Traces
 digital transformation,Digital Transformation
@@ -2534,21 +2092,16 @@ digital video frame rates,Digital Video Frame Rates
 digital writing system,Digital Writing System
 Digitisation,Digitization
 DIGITIZATION,Digitization
-Digitization,Digitization
 Digitization of industrial forms,Digitization Of Industrial Forms
 Digitization process,Digitization Process
 DIGITIZED ANALYSIS,Digitized Analysis
-Digitizer,Digitizer
 digitizer,Digitizer
 digit,Digits
 DIGITS,Digits
-Digits,Digits
 digits,Digits
 Dijkstra's algorithm,Dijkstra's Algorithm
-Dilation,Dilation
 dilation,Dilation
 DIMENSION,Dimension
-Dimension,Dimension
 Dimension reduction,Dimension Reduction
 dimension reduction,Dimension Reduction
 DIMENSIONALITY,Dimensionality
@@ -2557,16 +2110,13 @@ DIMENSIONALITY REDUCTION,Dimensionality Reduction
 Dimensionality reduction,Dimensionality Reduction
 dimensionality reduction,Dimensionality Reduction
 DIMENSIONS,Dimensions
-Diplomatization,Diplomatization
 DIRECT LDA,Direct LDA
-Direct Matching Points,Direct Matching Points
 direct pointing,Direct Pointing
 Directed Acyclic Graph (DAG),Directed Acyclic Graph
 Directed hausdorff distance,Directed Hausdorff Distance
 DIRECTED SEGMENTATION,Directed Segmentation
 DIRECTION,Direction
 direction coding,Direction Coding
-Direction Feature,Direction Feature
 Direction histogram,Direction Histogram
 direction motion,Direction Motion
 directional chain code feature,Directional Chain Code Feature
@@ -2575,13 +2125,10 @@ Directional distance distribution,Directional Distance Distribution
 directional element feature,Directional Element Feature
 Directional feature,Directional Feature
 Directional feature map,Directional Feature Map
-Directional Features,Directional Features
 Directional features,Directional Features
 directional features,Directional Features
 directional histogram,Directional Histogram
-Directional Pattern,Directional Pattern
 directional probability density function,Directional Probability Density Function
-Directional Relationships,Directional Relationships
 directional roses,Directional Roses
 directional skeletons,Directional Skeletons
 directional stroke,Directional Stroke
@@ -2602,15 +2149,11 @@ Discrete Cosine Transform (DCT),Discrete Cosine Transform
 Discrete cosine transform (DCT),Discrete Cosine Transform
 Discrete cosine transform (DCT) Feature Extraction,Discrete Cosine Transform Feature Extraction
 discrete curvelet transforms,Discrete Curvelet Transforms
-Discrete Event,Discrete Event
 discrete Fourier transform,Discrete Fourier Transform
 Discrete Frechet distance,Discrete Frechet Distance
-Discrete Hidden Markov Models,Discrete Hidden Markov Models
-Discrete Local Symmetry,Discrete Local Symmetry
 discrete orthogonal moments,Discrete Orthogonal Moments
 discrete radon transform,Discrete Radon Transform
 discrete relaxation,Discrete Relaxation
-Discrete Wavelet Transform,Discrete Wavelet Transform
 Discrete wavelet transform,Discrete Wavelet Transform
 discrete wavelet transform,Discrete Wavelet Transform
 Discrete Wavelet Transform (DWT),Discrete Wavelet Transform
@@ -2618,7 +2161,6 @@ Discrete wavelet transform (DWT),Discrete Wavelet Transform
 DISCRIMINANT,Discriminant
 discriminant analysis,Discriminant Analysis
 DISCRIMINANT-ANALYSIS,Discriminant Analysis
-Discriminant Function,Discriminant Function
 Discriminant learning,Discriminant Learning
 DISCRIMINATION,Discrimination
 discrimination ability,Discrimination Ability
@@ -2648,14 +2190,11 @@ dissimilarity representation,Dissimilarity Representation
 DISTANCE,Distance
 distance function,Distance Function
 Distance matching,Distance Matching
-Distance Measures,Distance Measures
 distance metric,Distance Metric
 Distance metric learning,Distance Metric Learning
-Distance Profile,Distance Profile
 Distance profile,Distance Profile
 distance set,Distance Set
 DISTANCE TRANSFORM,Distance Transform
-Distance Transform,Distance Transform
 distance-based segmentation,Distance-Based Segmentation
 DISTANCES,Distances
 distinctive calligraphy art,Distinctive Calligraphy Art
@@ -2669,7 +2208,6 @@ distribution,Distribution
 distribution analysis,Distribution Analysis
 distribution on a circle,Distribution On A Circle
 DISTRIBUTIONS,Distributions
-DIVA-HisDB,DIVA-HisDB
 DIVERSITY,Diversity
 diversity,Diversity
 diversity in handwritten shapes,Diversity In Handwritten Shapes
@@ -2681,14 +2219,10 @@ divide-and-conquer,Divide And Conquer
 divide and conquer based recursive autothresholding algorithm,Divide And Conquer Based Recursive Autothresholding Algorithm
 divide and conquer methods,Divide And Conquer Methods
 Division point feature,Division Point Feature
-DNN,DNN
-DNN HMM,DNN HMM
 DNN-HMM,DNN HMM
-Doctors Cursive Handwriting,Doctors Cursive Handwriting
 DOCUMENT,Document
 Document aging,Document Aging
 DOCUMENT ANALYSIS,Document Analysis
-Document Analysis,Document Analysis
 Document analysis,Document Analysis
 document analysis,Document Analysis
 Document analysis and processing,Document Analysis And Processing
@@ -2715,7 +2249,6 @@ Document enhancement and restoration,Document Enhancement And Restoration
 Document handling,Document Handling
 Document image,Document Image
 document image,Document Image
-Document Image Analysis,Document Image Analysis
 Document image analysis,Document Image Analysis
 document image analysis,Document Image Analysis
 document image binarisation algorithms,Document Image Binarisation Algorithms
@@ -2725,7 +2258,6 @@ document image binarization contest,Document Image Binarization Contest
 document image content extraction,Document Image Content Extraction
 document image dataset,Document Image Dataset
 Document image pre-processing,Document Image Pre-Processing
-Document Image Processing,Document Image Processing
 Document image processing,Document Image Processing
 document image processing,Document Image Processing
 document image registration,Document Image Registration
@@ -2739,16 +2271,13 @@ document images,Document Images
 document images binarization,Document Images Binarization
 document imaging,Document Imaging
 document indexing,Document Indexing
-Document Layout Analysis,Document Layout Analysis
 Document layout analysis,Document Layout Analysis
 document layout analysis,Document Layout Analysis
-Document Processing,Document Processing
 Document processing,Document Processing
 document processing,Document Processing
 DOCUMENT RECOGNITION,Document Recognition
 document recognition,Document Recognition
 document restoration,Document Restoration
-Document Retrieval,Document Retrieval
 Document retrieval,Document Retrieval
 document retrieval,Document Retrieval
 Document security,Document Security
@@ -2783,7 +2312,6 @@ DOMINANT POINT DETECTION,Dominant Point Detection
 dominant points,Dominant Points
 Dominant points-based feature extraction,Dominant Points-Based Feature Extraction
 doodle,Doodles
-Doodles,Doodles
 DOPAMINE,Dopamine
 dopamine,Dopamine
 doping,Doping
@@ -2793,9 +2321,6 @@ dot assignment,Dot Assignment
 dot descriptors,Dot Descriptors
 down sampling,Down Sampling
 Down-> up-> down strategy,Down-> Up-> Down Strategy
-DP,DP
-DP matching,DP matching
-DRAM,DRAM
 drawing,Drawing
 DRAWING MOVEMENTS,Drawing Movements
 drawing order,Drawing Order
@@ -2806,15 +2331,12 @@ Drop in egg production,Drop In Egg Production
 DropConnect,Dropconnect
 dropconnect,Dropconnect
 DROPOUT,Dropout
-Dropout,Dropout
 dropout,Dropout
 drop-out,Dropout
 Dropout layer,Dropout Layer
 Dropout regularization,Dropout Regularization
 dropout training,Dropout Training
-DRT,DRT
 Drug administration systems,Drug Administration Systems
-DTW,DTW
 Dual routing cooperation,Dual Routing Cooperation
 dual tasking,Dual Task
 dual-task,Dual Task
@@ -2822,13 +2344,10 @@ Dual-tree complex wavelet packet transform,Dual-Tree Complex Wavelet Packet Tran
 Duplicated samples,Duplicated Samples
 DURATION,Duration
 dust-free,Dust-Free
-DWT,DWT
-Dynamic Bayesian Network,Dynamic Bayesian Network
 Dynamic Bayesian network,Dynamic Bayesian Network
 dynamic Bayesian network,Dynamic Bayesian Network
 dynamic Bayesian networks,Dynamic Bayesian Networks
 dynamic biometric signature,Dynamic Biometric Signature
-dynamic BN,dynamic BN
 dynamic classifier selection,Dynamic Classifier Selection
 Dynamic dictionary,Dynamic Dictionary
 Dynamic features,Dynamic Features
@@ -2843,16 +2362,12 @@ dynamic programming,Dynamic Programming
 Dynamic range,Dynamic Range
 dynamic recognition based on features,Dynamic Recognition Based On Features
 dynamic reconfigurability,Dynamic Reconfigurability
-Dynamic Reconfiguration,Dynamic Reconfiguration
 dynamic reconfiguration,Dynamic Reconfiguration
-dynamic recurrent OS-ELM,dynamic recurrent OS-ELM
-Dynamic Resizing,Dynamic Resizing
 dynamic selection,Dynamic Selection
 DYNAMIC SIGNATURE,Dynamic Signature
 DYNAMIC SIGNATURE VERIFICATION,Dynamic Signature Verification
 Dynamic signature verification,Dynamic Signature Verification
 Dynamic signatures,Dynamic Signatures
-Dynamic Time Warping,Dynamic Time Warping
 Dynamic time warping,Dynamic Time Warping
 dynamic time warping,Dynamic Time Warping
 Dynamic Time Warping (DTW),Dynamic Time Warping
@@ -2873,22 +2388,16 @@ DYSLEXIA,Dyslexia
 dyslexia,Dyslexia
 dystonia,Dystonia
 Eager interpretation,Eager Interpretation
-EANN,EANN
-Early Bearing Fault Detection,Early Bearing Fault Detection
 Early education,Early Education
-Early Grade Writing Assessment,Early Grade Writing Assessment
 early intervention,Early Intervention
 Early literacy,Early Literacy
 early management,Early Management
 early visual processing,Early Visual Processing
 Early warning,Early Warning
 Earth Movers Distance,Earth Mover's Distance
-Earth Mover's Distance,Earth Mover's Distance
 Eastern Arabic numerals,Eastern Arabic Numerals
-Eavesdropping,Eavesdropping
 eavesdropping,Eavesdropping
 eBeam whiteboard interface,eBeam Whiteboard Interface
-ECOC,ECOC
 E-content development,E-Content Development
 edge continuity relation,Edge Continuity Relation
 edge cue,Edge Cue
@@ -2906,15 +2415,12 @@ edit distance,Edit Distance
 edit-distance,Edit Distance
 Edition distance,Edit Distance
 EDUCATION,Education
-Education,Education
 education,Education
 Educational assessment,Educational Assessment
 educational documents,Educational Documents
 Educational system,Educational System
 educational technologies,Educational Technologies
 Educational technology,Educational Technologies
-EEG,EEG
-EER,EER
 Effective features,Effective Features
 effectiveness,Effectiveness
 EFFICIENCY,Efficiency
@@ -2926,20 +2432,14 @@ efficient training,Efficient Training
 Egocentric vision,Egocentric Vision
 E-health,E-Health
 eigen profiles,Eigen Profiles
-Eigencharacter,Eigencharacter
 eigen-deformation,Eigen-Deformation
 EIGENFACES,Eigenfaces
-Eigenfaces,Eigenfaces
 eigenvectors,Eigenvectors
 E-interaction,E-Interaction
-Ekush,Ekush
 ekush dataset,Ekush Dataset
-Elastic Distortion,Elastic Distortion
 Elastic matching,Elastic Matching
 elastic matching,Elastic Matching
 Elastic memory learning,Elastic Memory Learning
-Elastic Meshes,Elastic Meshes
-Elastic Meshing,Elastic Meshing
 elastic meshing based on wavelet transform,Elastic Meshing Based On Wavelet Transform
 elastic models,Elastic Models
 Elastic net,Elastic Net
@@ -2950,7 +2450,6 @@ eLearning,E-Learning
 E-learning,E-Learning
 e-learning,E-Learning
 E-LEARNING SYSTEMS,E-Learning Systems
-Election,Election
 Electric circuit diagram,Electric Circuit Diagram
 ELECTRODE,Electrode
 electromyography,Electromyography
@@ -2981,33 +2480,23 @@ elicitation study,Elicitation Study
 Elliptic arc,Elliptic Arc
 elliptic trajectory modeling,Elliptic Trajectory Modeling
 Elliptical based features,Elliptical Based Features
-ELM,ELM
 ELM classifier,ELM Classifier
 ELM-based autoencoder,ELM-Based Autoencoder
-ELNET-II,ELNET-II
-ELU,ELU
 EM ALGORITHM,EM Algorithm
 EM algorithm,EM Algorithm
-EMA,EMA
 embedded attributes,Embedded Attributes
 embedded computer vision,Embedded Computer Vision
-Embedded Linux,Embedded Linux
-Embedded MPU,Embedded MPU
 EMBEDDED SYSTEMS,Embedded Systems
 embedded systems,Embedded Systems
 embedded texts,Embedded Texts
 embedded training,Embedded Training
-Embedding,Embedding
 Embedding fusion,Embedding Fusion
 embodiment,Embodiment
-EMD,EMD
 EMERGENCY MEDICAL SERVICES,Emergency Medical Services
 emergent computation,Emergent Computation
 Emergent literacy,Emergent Literacy
 emergent literacy,Emergent Literacy
-Emerging Devices,Emerging Devices
 emerging non-volatile memory,Emerging Non-Volatile Memory
-EMG,EMG
 Emg acquisition system,EMG Acquisition System
 EMG PATTERN-RECOGNITION,EMG Pattern-Recognition
 emg processing,EMG Processing
@@ -3026,12 +2515,8 @@ encoder decoder,Encoder-Decoder
 Encoder/Decoder,Encoder-Decoder
 Encoder-decoder,Encoder-Decoder
 encoder-decoder,Encoder-Decoder
-Encoder-Decoder Convolutional Neural Network,Encoder-Decoder Convolutional Neural Network
-Encoder-Decoder Network,Encoder-Decoder Network
 encoder-decoder network,Encoder-Decoder Network
-Encoding,Encoding
 encoding,Encoding
-Encog,Encog
 Endangered languages,Endangered Languages
 ENDOSCOPIC SINUS SURGERY,Endoscopic Sinus Surgery
 endpoint information,Endpoint Information
@@ -3058,17 +2543,13 @@ ENERGY MANAGEMENT-SYSTEM,Energy Management-System
 energy-based,Energy-Based
 ENGINEERING APPLICATIONS,Engineering Applications
 Engineering drawing,Engineering Drawing
-Engineering Education,Engineering Education
 ENGLISH,English
-English Alphabets Dataset,English Alphabets Dataset
 English and Kannada Handwritten Documents,English And Kannada Handwritten Documents
 English database,English Database
 English handwritten text,English Handwritten Text
 English recognition,English Recognition
 English text recognition,English Text Recognition
 enhanced image,Enhanced Image
-Enhanced Probabilistic Convergent Network,Enhanced Probabilistic Convergent Network
-Enhanced Water Reservoir,Enhanced Water Reservoir
 ENHANCEMENT,Enhancement
 enhancement,Enhancement
 ENIT Arabic dataset,Enit Arabic Dataset
@@ -3084,35 +2565,27 @@ ensemble creation method,Ensemble Creation Method
 Ensemble learning,Ensemble Learning
 ensemble learning,Ensemble Learning
 ensemble method,Ensemble Methods
-Ensemble Methods,Ensemble Methods
 Ensemble methods,Ensemble Methods
 ensemble methods,Ensemble Methods
-Ensemble Neural Network,Ensemble Neural Network
 ensemble of classifiers,Ensemble Of Classifiers
 ensemble size,Ensemble Size
 ENSEMBLES,Ensembles
-Ensembles,Ensembles
 Ensembles of classifiers,Ensembles Of Classifiers
 ENTROPY,Entropy
-Entropy,Entropy
 entropy,Entropy
 entropy minimization,Entropy Minimization
-Entropy-Based Histogram Segmentation,Entropy-Based Histogram Segmentation
 entropy-based metric,Entropy-Based Metric
 ENTRY,Entry
 environmental monitoring,Environmental Monitoring
 ENVIRONMENTS,Environments
-EOH,EOH
 epidemiology,Epidemiology
 Epigraphic documents,Epigraphic Documents
 epigraphy,Epigraphy
-Epochs,Epochs
 EQUALIZATION,Equalization
 equation editing,Equation Editing
 equation parsing,Equation Parsing
 Equimass segmentation,Equimass Segmentation
 EQUIPMENT HEALTH DIAGNOSIS,Equipment Health Diagnosis
-Erasmus Intensive Programmes,Erasmus Intensive Programmes
 erasure characterization,Erasure Characterization
 erasure detection,Erasure Detection
 E-recognition,E-Recognition
@@ -3128,7 +2601,6 @@ Error correcting output code,Error Correcting Output Code
 ERROR CORRECTION,Error Correction
 Error correction,Error Correction
 error correction,Error Correction
-Error Detection,Error Detection
 Error detection,Error Detection
 error diversity,Error Diversity
 error estimation,Error Estimation
@@ -3147,24 +2619,19 @@ essential tremor,Essential Tremor
 Essential tremor diagnosis,Essential Tremor Diagnosis
 estimating pen trajectories of static scripts,Estimating Pen Trajectories Of Static Scripts
 estimation error,Estimation Error
-etc.,etc.
 E-testing tools,E-Testing Tools
 Ethiopic script,Ethiopic Script
-ETL9B,ETL9B
 ETL-9B database,ETL9B Database
 Euclidean Distance,Euclidian Distance
 Euclidean distance,Euclidian Distance
-Euclidian Distance,Euclidian Distance
 Euclidian distance,Euclidian Distance
 Euclidean distance metric,Euclidian Distance Metric
 Euler method,Euler Method
 Euler path,Euler Path
 European dimension,European Dimension
-Evaluation,Evaluation
 evaluation,Evaluation
 evaluation campaign,Evaluation Campaign
 Evaluation methodologies,Evaluation Methodologies
-Evaluation Metrics,Evaluation Metrics
 Evaluation metrics,Evaluation Metrics
 evaluation metrics,Evaluation Metrics
 Evaluation performance,Evaluation Performance
@@ -3188,32 +2655,27 @@ evolutionary self-organizing map,Evolutionary Self-Organizing Map
 evolved gradient direction optimizer (EVGO),Evolved Gradient Direction Optimizer
 evolving classifiers,Evolving Classifiers
 exact line boundary,Exact Line Boundary
-Examination,Examination
 Examination paper,Examination Paper
 examination paper,Examination Paper
 excessive usage,Excessive Usage
 excitation,Excitation
-Executable Model Based Design,Executable Model Based Design
 Execution periods,Execution Periods
 execution plan,Execution Plan
 EXECUTIVE FUNCTIONS,Executive Functions
 existing OCR systems,Existing OCR Systems
 existing Persian OCR system,Existing Persian OCR System
-Expectation Maximization,Expectation Maximization
 Expectation maximization,Expectation Maximization
 expectation-maximization,Expectation Maximization
 EXPECTATIONS,Expectations
 EXPERIENCE,Experience
 Experimental reproducibility,Experimental Reproducibility
 Experimental study,Experimental Study
-Experimentation,Experimentation
 expert classifiers,Expert Classifiers
 Expert system,Expert System
 expert system,Expert System
 expert systems,Expert System
 expert system validation,Expert System Validation
 EXPERTS,Experts
-Experts,Experts
 expert's classifier,Expert's Classifier
 explainable deep learning,Explainable Deep Learning
 explanation expert,Explanation Expert
@@ -3224,7 +2686,6 @@ explicit state duration,Explicit State Duration
 EXPOSING DIGITAL FORGERIES,Exposing Digital Forgeries
 EXPRESSIONS,Expressions
 expressions,Expressions
-Extended Zoning,Extended Zoning
 extension matrix theory,Extension Matrix Theory
 EXTERNAL CUES,External Cues
 External symmetry axis,External Symmetry Axis
@@ -3233,12 +2694,10 @@ extraction,Extraction
 Extrapage publisher,Extrapage Publisher
 extreme coordinates,Extreme Coordinates
 eXtreme gradient boosting (XGBoost),Extreme Gradient Boosting
-Extreme Learning Machine,Extreme Learning Machine
 Extreme learning machine,Extreme Learning Machine
 Extreme learning machine (ELM),Extreme Learning Machine
 Extreme Learning Machines,Extreme Learning Machine
 EXTREME LEARNING-MACHINE,Extreme Learning Machine
-Extremely Randomized Trees,Extremely Randomized Trees
 EYE,Eye
 eye writing,Eye Writing
 Eye-hand coordination,Eye-Hand Coordination
@@ -3257,7 +2716,6 @@ FACE-RECOGNITION ALGORITHMS,Face-Recognition Algorithms
 FACIAL EXPRESSION RECOGNITION,Facial Expression Recognition
 Facial feature extraction,Facial Feature Extraction
 facial video analysis,Facial Video Analysis
-Facsimile,Facsimile
 factor analysis,Factor Analysis
 factor graph,Factor Graph
 FACTOR MODELS,Factor Models
@@ -3265,23 +2723,18 @@ FAILURE,Failure
 FAMILIARITY,Familiarity
 family history technology,Family History Technology
 FAR,Far
-Farsi,Farsi
 Farsi database,Farsi Database
 Farsi handwriting,Farsi Handwriting
 Farsi handwritten recognition,Farsi Handwritten Recognition
 Farsi numeral recognition,Farsi Numeral Recognition
 Farsi Persian Arabic subword,Farsi Persian Arabic Subword
 "Farsi, Persian, Arabic font","Farsi, Persian, Arabic Font"
-Farsi/Arabic Document Analysis,Farsi/Arabic Document Analysis
 Farsi/Arabic handwriting recognition,Farsi/Arabic Handwriting Recognition
-Farsi/Arabic Handwritten OCR,Farsi/Arabic Handwritten OCR
 Farsi/Arabic text recognition,Farsi/Arabic Text Recognition
-Farsi/Persian OCR,Farsi/Persian OCR
 FAST,Fast
 fast adaptation,Fast Adaptation
 Fast Boolean matching,Fast Boolean Matching
 FAST corner detection,Fast Corner Detection
-Fast DTW,Fast DTW
 fast edge-feature extraction,Fast Edge-Feature Extraction
 fast Fourier transform,Fast Fourier Transform
 Fast Fourier transform (FFT),Fast Fourier Transform
@@ -3295,33 +2748,23 @@ FAST PARALLEL ALGORITHM,Fast Parallel Algorithm
 Fast rejection,Fast Rejection
 fast training,Fast Training
 Faster R-CNN,Faster-RCNN
-Faster-RCNN,Faster-RCNN
 Fast I-CA,Fast-ICA
-Fast-ICA,Fast-ICA
 Fault diagnosis,Fault Diagnosis
 fault recognition,Fault Recognition
 Fault tolerance,Fault Tolerance
 FAULT-TOLERANT KEY ACCESS TO FILES BY DICTIONARY,Fault-Tolerant Key Access To Files By Dictionary
 FAX,Fax
 FAX-OCR SYSTEM,Fax-OCR System
-FCN,FCN
-FCN,FCN
-FCOS,FCOS
-FDIR,FDIR
-Feature,Feature
 feature,Feature
 feature analysis,Feature Analysis
 feature and sample sparsity,Feature And Sample Sparsity
 Feature based techniques,Feature Based Techniques
-Feature Combination,Feature Combination
 Feature combination,Feature Combination
 feature combination,Feature Combination
 Feature combinations,Feature Combination
-Feature Computation,Feature Computation
 feature definition,Feature Definition
 FEATURE DENSITY EQUALIZATION,Feature Density Equalization
 feature description language,Feature Description Language
-Feature Descriptor,Feature Descriptor
 feature design,Feature Design
 Feature detection,Feature Detection
 feature dimensionality reduction,Feature Dimensionality Reduction
@@ -3331,13 +2774,11 @@ feature evaluation,Feature Evaluation
 Feature evaluation and selection,Feature Evaluation And Selection
 feature extracted,Feature Extracted
 FEATURE EXTRACTION,Feature Extraction
-Feature Extraction,Feature Extraction
 Feature extraction,Feature Extraction
 feature extraction,Feature Extraction
 Features Extraction,Feature Extraction
 Features extraction,Feature Extraction
 features extraction,Feature Extraction
-Feature Extraction Algorithm,Feature Extraction Algorithm
 feature extraction algorithm,Feature Extraction Algorithm
 feature extraction and analysis,Feature Extraction And Analysis
 Feature Extraction and Selection,Feature Extraction And Selection
@@ -3359,17 +2800,12 @@ feature induction,Feature Induction
 Feature learning,Feature Learning
 feature learning,Feature Learning
 feature level fusion and K-NN,Feature Level Fusion And K-NN
-Feature Matching,Feature Matching
 feature matching,Feature Matching
-Feature Measurement,Feature Measurement
 feature measurement,Feature Measurement
 feature modeling,Feature Modeling
-Feature Normalization,Feature Normalization
-Feature Points,Feature Points
 FEATURE PROJECTION,Feature Projection
 Feature ranking/succession,Feature Ranking/Succession
 feature region,Feature Region
-Feature Representation,Feature Representation
 feature representation,Feature Representation
 feature representations,Feature Representations
 feature selectio,Feature Selection
@@ -3383,7 +2819,6 @@ Feature subset selection,Feature Subset Selection
 FEATURE SUBSET-SELECTION,Feature Subset Selection
 feature tracking,Feature Tracking
 Feature transformation,Feature Transformation
-Feature Vector,Feature Vector
 feature vector,Feature Vector
 Feature Vectors,Feature Vector
 feature vectors,Feature Vector
@@ -3424,19 +2859,13 @@ Feedforward and feedback processing,Feedforward And Feedback Processing
 feedforward model,Feedforward Model
 Feedforward neural network language model,Feedforward Neural Network Language Model
 few shot learning,Few Shot Learning
-FFT,FFT
-FHMMs,FHMMs
-FI,FI
 field classification,Field Classification
-Field Content Recognition,Field Content Recognition
-Field Detection,Field Detection
 Field localization,Field Localization
 field localization,Field Localization
 field programmable gate arrays,Field Programmable Gate Arrays
 field study,Field Study
 figure,Figure
 Figure detection,Figure Detection
-Filipino Sign Language,Filipino Sign Language
 FILLER,Filler
 film scanner,Film Scanner
 FILMS,Films
@@ -3460,7 +2889,6 @@ FINGER FUNCTION,Finger Function
 Finger grip pressure sensing,Finger Grip Pressure Sensing
 Finger input,Finger Input
 Finger tip detection,Finger Tip Detection
-Finger Writing,Finger Writing
 FINGERPRINT,Fingerprint
 fingerprint,Fingerprint
 Fingerprint image enhancements,Fingerprint Image Enhancements
@@ -3470,7 +2898,6 @@ Fingertip detection,Fingertip Detection
 Fingertip detection and tracking,Fingertip Detection And Tracking
 Fingerwriting posture recognition,Fingerwriting Posture Recognition
 finite impulse response neural network,Finite Impulse Response Neural Network
-Finite State Automata,Finite State Automata
 finite state machine,Finite State Machine
 Finite State Transducer (FST),Finite State Transducer
 finite state transducers,Finite State Transducer
@@ -3478,31 +2905,23 @@ finite-state transducers,Finite State Transducer
 FINITE-STATE MACHINES,Finite-State Machines
 Finite-State machines,Finite-State Machines
 First grade,First Grade
-First Temple Period,First Temple Period
 first-order rule induction,First-Order Rule Induction
 Fisher profiles,Fisher Profiles
 Fisher's linear discriminant,Fisher's Linear Discriminant
 fitness function,Fitness Function
 fixed-point arithmetic,Fixed-Point Arithmetic
-FLD,FLD
 flexible smart cameras,Flexible Smart Cameras
 flexible structural matching,Flexible Structural Matching
 floating feature detector,Floating Feature Detector
 FLOATING SEARCH METHODS,Floating Search Methods
 Floor plan analysis,Floor Plan Analysis
-Flowchart,Flowchart
 flowchart,Flowchart
 flowcharts,Flowchart
 Flowchart recognition,Flowchart Recognition
 flowchart recognition,Flowchart Recognition
-Flower Pollination Algorithm,Flower Pollination Algorithm
-Fluctuated,Fluctuated
 FLUENCY,Fluency
-Fluency,Fluency
 fluency,Fluency
-FMCW radar,FMCW radar
 F-measure,F-Measure
-FMRI,FMRI
 fMRI,FMRI
 FOHDEL language,Fohdel Language
 FONT,Font
@@ -3511,22 +2930,18 @@ font sets,Font Sets
 Font/size recognition,Font/Size Recognition
 FOOD,Food
 FORCE,Force
-Force,Force
 force vector,Force Vector
 foreground features,Foreground Features
 foreign handwriting style,Foreign Handwriting Style
-Forensic,Forensic
 FORENSICS,Forensic
 Forensics,Forensic
 forensics,Forensic
-Forensic Analysis,Forensic Analysis
 forensic analysis,Forensic Analysis
 forensic casework,Forensic Casework
 forensic data,Forensic Data
 forensic document examination,Forensic Document Examination
 Forensic handwriting examination,Forensic Handwriting Examination
 forensic handwriting examination,Forensic Handwriting Examination
-Forensic Handwriting Experts,Forensic Handwriting Experts
 forensic handwriting identification,Forensic Handwriting Identification
 forensic image processing,Forensic Image Processing
 Forensic science,Forensic Science
@@ -3543,15 +2958,12 @@ Forgery,Forgeries
 forgery,Forgeries
 Forgery detection,Forgery Detection
 forgery detection,Forgery Detection
-Forget Gate,Forget Gate
 Forgetting of unused classes,Forgetting Of Unused Classes
 fork point,Fork Point
-Form,Form
 form design,Form Design
 Form Detection and Table Recognition,Form Detection And Table Recognition
 form document,Form Document
 form identification,Form Identification
-Form Processing,Form Processing
 Form processing,Form Processing
 form processing,Form Processing
 forms processing,Form Processing
@@ -3568,25 +2980,16 @@ forward propagation,Forward Propagation
 Forward-backward (FB) algorithm,Forward-Backward Algorithm
 FORWARD-BACKWARD ALGORITHM,Forward-Backward Algorithm
 forward-backward procedure,Forward-Backward Procedure
-Four Arithmetic Operations,Four Arithmetic Operations
-Fourier,Fourier
 Fourier coefficients,Fourier Coefficients
 fourier descriptor,Fourier Descriptor
 FOURIER DESCRIPTORS,Fourier Descriptors
-Fourier Descriptors,Fourier Descriptors
 Fourier descriptors,Fourier Descriptors
-Fourier Elliptic,Fourier Elliptic
-Fourier Transform,Fourier Transform
 Fourier transform,Fourier Transform
 FOURIER-TRANSFORM,Fourier Transform
 Fourier transformation,Fourier Transformation
 Fourier-Mellin transform,Fourier-Mellin Transform
 foveation,Foveation
-FPGA,FPGA
 FPGAs,FPGA
-FPGA acceleration,FPGA acceleration
-FPGA in loop,FPGA in loop
-FPGA-based smart camera,FPGA-based smart camera
 fractal,Fractal
 Fractal coding,Fractal Coding
 fractal compression,Fractal Compression
@@ -3601,7 +3004,6 @@ FRAME-BASED PROCESSING,Frame-Based Processing
 FRAMES,Frames
 framewise training,Framewise Training
 FRAMEWORK,Framework
-Framework,Framework
 Fraud document,Fraud Document
 FREAK,Freak
 free energy,Free Energy
@@ -3609,7 +3011,6 @@ Free-form handwriting,Free-Form Handwriting
 free-format handwriting recognition,Free-Format Handwriting Recognition
 Freehand drawing,Freehand Drawing
 freehand drawing,Freehand Drawing
-Freeman Chain Code,Freeman Chain Code
 Freeman chain code,Freeman Chain Code
 Freeman Chain Code (FCC),Freeman Chain Code
 Freeman chain code (FCC),Freeman Chain Code
@@ -3626,11 +3027,7 @@ Frequency-based organization,Frequency-Based Organization
 frequent features,Frequent Features
 Frequent pattern mining,Frequent Pattern Mining
 FRICTION LAYER,Friction Layer
-FRR,FRR
 Fruit fly optimization algorithm,Fruit Fly Optimization Algorithm
-FSA,FSA
-F-Score,F-Score
-FSM,FSM
 Fukunaga-Koontz transform,Fukunaga-Koontz Transform
 fully automatic blackboard eraser,Fully Automatic Blackboard Eraser
 Fully connected dropout,Fully Connected Dropout
@@ -3641,7 +3038,6 @@ Fully Convolutional Neural Networks,Fully Convolutional Neural Network
 Fully convolutional neural networks,Fully Convolutional Neural Network
 fully convolutional neural networks,Fully Convolutional Neural Network
 fully gated convolutional neural networks,Fully Gated Convolutional Neural Networks
-FUN,FUN
 Function based technique,Function Based Technique
 THE FUNCTION OF DISTANCE,Function Of Distance
 Functional ANalysis Of VAriance (fANOVA),Functional Analysis Of Variance
@@ -3653,13 +3049,11 @@ FUNCTIONAL-PROPERTIES,Functional-Properties
 Furay perceptual codes,Furay Perceptual Codes
 FUSIFORM FACE AREA,Fusiform Face Area
 FUSION,Fusion
-Fusion,Fusion
 fusion,Fusion
 fusion convolutional neural network,Fusion Convolutional Neural Network
 fusion rules,Fusion Rules
 FUTURE,Future
 FUZZY,Fuzzy
-Fuzzy,Fuzzy
 fuzzy,Fuzzy
 Fuzzy age,Fuzzy Age
 fuzzy aggregation,Fuzzy Aggregation
@@ -3667,19 +3061,16 @@ fuzzy ARTMAP,Fuzzy Artmap
 Fuzzy assignment of diacritics,Fuzzy Assignment Of Diacritics
 fuzzy associative memory,Fuzzy Associative Memory
 FUZZY ATTRIBUTE REPRESENTATION,Fuzzy Attribute Representation
-Fuzzy Attributed Relational Graph,Fuzzy Attributed Relational Graph
 fuzzy automata,Fuzzy Automata
 fuzzy basis function networks,Fuzzy Basis Function Networks
 fuzzy basis functions,Fuzzy Basis Functions
 Fuzzy binary relation,Fuzzy Binary Relation
-Fuzzy Classifier,Fuzzy Classifier
 fuzzy clustering,Fuzzy Clustering
 Fuzzy c-means,Fuzzy C-Means
 fuzzy c-means clustering algorithm,Fuzzy C-Means Clustering Algorithm
 fuzzy context-free grammar,Fuzzy Context-Free Grammar
 fuzzy direction,Fuzzy Direction
 Fuzzy elastic pattern,Fuzzy Elastic Pattern
-Fuzzy Elementary Perceptual Codes,Fuzzy Elementary Perceptual Codes
 fuzzy e-means clustering algorithm,Fuzzy E-Means Clustering Algorithm
 fuzzy features,Fuzzy Features
 fuzzy handwriting recognition,Fuzzy Handwriting Recognition
@@ -3694,7 +3085,6 @@ FUZZY INTEGRALS,Fuzzy Integrals
 fuzzy integrals,Fuzzy Integrals
 fuzzy language,Fuzzy Language
 fuzzy linguistic features,Fuzzy Linguistic Features
-Fuzzy Logic,Fuzzy Logic
 Fuzzy logic,Fuzzy Logic
 fuzzy logic,Fuzzy Logic
 Fuzzy logics,Fuzzy Logic
@@ -3710,7 +3100,6 @@ Fuzzy MIN-MAX,Fuzzy Min-Max
 Fuzzy MIN-MAX combination,Fuzzy Min-Max Combination
 fuzzy model,Fuzzy Model
 fuzzy modeling,Fuzzy Modeling
-Fuzzy Neural Network,Fuzzy Neural Network
 fuzzy neural network,Fuzzy Neural Network
 fuzzy neural networks,Fuzzy Neural Network
 fuzzy number,Fuzzy Numbers
@@ -3736,49 +3125,39 @@ fuzzy triangular membership function,Fuzzy Triangular Membership Function
 fuzzy vault,Fuzzy Vault
 fuzzy vector quantization,Fuzzy Vector Quantization
 FUZZY-ATTRIBUTE GRAPH,Fuzzy-Attribute Graph
-Gabor,Gabor
 gabor energy features,Gabor Energy Features
 Gabor feature,Gabor Feature
 Gabor features,Gabor Features
 Gabor fillers,Gabor Fillers
-Gabor Filter,Gabor Filter
 Gabor filter,Gabor Filter
 gabor filter,Gabor Filter
 GABOR FILTERS,Gabor Filter
 Gabor filters,Gabor Filter
 gabor filters,Gabor Filter
-Gabor Filter Algorithm,Gabor Filter Algorithm
 Gabor Filter Response features,Gabor Filter Response Features
 Gabor filtering,Gabor Filtering
 Gabor parameter optimization,Gabor Parameter Optimization
-Gabor phaser XNOR pattern,Gabor phaser XNOR pattern
 Gabor transform-based features,Gabor Transform-Based Features
 Gabor wavelet,Gabor Wavelet
-GACV,GACV
 GAIT ANALYSIS,Gait Analysis
 GAIT RECOGNITION,Gait Recognition
 GAIT VARIABILITY,Gait Variability
 Galois connections,Galois Connections
 game,Game
 GAME BOT DETECTION,Game Bot Detection
-Gamification,Gamification
 gamma correction,Gamma Correction
 GAN-generated handwriting styles,GAN-Generated Handwriting Styles
 Gate guided,Gate Guided
-Gated Fully Convolutional Networks,Gated Fully Convolutional Networks
 gated memory unit,Gated Memory Unit
 gated recurrent unit,Gated Recurrent Unit
 Gaussian distribution,Gaussian Distribution
 guassian distribution,Gaussian Distribution
 Gaussian distribution selector,Gaussian Distribution Selector
-Gaussian Grid Feature,Gaussian Grid Feature
 Gaussian grid feature,Gaussian Grid Feature
 gaussian grid fratures,Gaussian Grid Feature
-Gaussian Mixture Model,Gaussian Mixture Model
 Gaussian mixture model (GMM),Gaussian Mixture Model
 Gaussian mixture model-hidden Markov model,Gaussian Mixture Model-Hidden Markov Model
 Gaussian mixture modeling,Gaussian Mixture Modeling
-Gaussian Mixture Models,Gaussian Mixture Models
 Gaussian mixture models,Gaussian Mixture Models
 Gaussian PDF clustering,Gaussian PDF Clustering
 Gaussian processes,Gaussian Processes
@@ -3786,12 +3165,9 @@ Gaussian surround,Gaussian Surround
 GAZE,Gaze
 gaze interaction,Gaze Interaction
 gaze tracking,Gaze Tracking
-GDD model,GDD model
-GEAR,GEAR
 Ge'ez Ancient Ethiopian language,Ge'ez Ancient Ethiopian Language
 GENDER,Gender
 gender,Gender
-Gender Classification,Gender Classification
 Gender classification,Gender Classification
 Gender detection,Gender Detection
 Gender identification,Gender Identification
@@ -3805,12 +3181,10 @@ generalisation problem,Generalisation Problem
 generality,Generality
 Generalizable and adaptable,Generalizable And Adaptable
 generalisation,Generalization
-Generalization,Generalization
 generalization,Generalization
 generalization ability,Generalization Ability
 generalized CPV (GCPV),Generalized CPV
 Generalized EM algorithm (GEM),Generalized EM Algorithm
-Generalized Hough Transform,Generalized Hough Transform
 Generalized Hough transform,Generalized Hough Transform
 GENERALIZED MOTOR PROGRAMS,Generalized Motor Programs
 generalized normalization transform,Generalized Normalization Transform
@@ -3820,7 +3194,6 @@ GENERALIZED-DELTA RULE,Generalized-Delta Rule
 generated code,Generated Code
 generating module,Generating Module
 GENERATION,Generation
-Generation,Generation
 GENERATION PROCESS,Generation Process
 generative adversarial imitation learning,Generative Adversarial Imitation Learning
 GAN,Generative Adversarial Networks
@@ -3836,7 +3209,6 @@ Generic multi strategy algorithm,Generic Multi Strategy Algorithm
 generic online handwriting recognition,Generic Online Handwriting Recognition
 GENERIC ORTHOGONAL MOMENTS,Generic Orthogonal Moments
 GENETIC ALGORITHM,Genetic Algorithm
-Genetic Algorithm,Genetic Algorithm
 Genetic algorithm,Genetic Algorithm
 genetic algorithm,Genetic Algorithm
 Genetic Algorithm (GA),Genetic Algorithm
@@ -3848,10 +3220,7 @@ genetic algorithms,Genetic Algorithm
 genetic algorithms (GA,Genetic Algorithm
 Genetic Algorithms (GA),Genetic Algorithm
 genetic algorithms (GA),Genetic Algorithm
-Genetic Clustering,Genetic Clustering
-Genetic Improvement,Genetic Improvement
 Genetic improvement,Genetic Improvement
-Genetic Programming,Genetic Programming
 Genetic programming,Genetic Programming
 genetic programming,Genetic Programming
 Genre knowledge,Genre Knowledge
@@ -3863,7 +3232,6 @@ geometric context,Geometric Context
 geometric context models,Geometric Context Models
 Geometric feature,Geometric Features
 geometric feature,Geometric Features
-Geometric Features,Geometric Features
 Geometric features,Geometric Features
 geometric features,Geometric Features
 Geometrical features,Geometric Features
@@ -3873,13 +3241,11 @@ geometric invariant moment,Geometric Invariant Moment
 Geometric knowledge embedding,Geometric Knowledge Embedding
 geometric learning,Geometric Learning
 geometric mean,Geometric Mean
-Geometric Modeling,Geometric Modeling
 Geometric Moment Invariant (GMI),Geometric Moments Invariants
 geometric moments invariants,Geometric Moments Invariants
 geometric representation,Geometric Representation
 geometric scores,Geometric Scores
 George Washington dataset,George Washington Dataset
-German,German
 German-language,German Language
 gestural input,Gestural Input
 gesture,Gesture
@@ -3888,7 +3254,6 @@ gesture input device,Gesture Input Device
 gesture keyboards,Gesture Keyboards
 Gesture on air,Gesture On Air
 GESTURE RECOGNITION,Gesture Recognition
-Gesture Recognition,Gesture Recognition
 Gesture recognition,Gesture Recognition
 gesture recognition,Gesture Recognition
 Gesture synthesis,Gesture Synthesis
@@ -3900,11 +3265,6 @@ Gibbs sampling,Gibbs Sampling
 GIST,Gist
 given handwriting,Given Handwriting
 given writer,Given Writer
-Glagolitsa,Glagolitsa
-GLBP,GLBP
-GLCM,GLCM
-GLCM feature,GLCM feature
-GLCM texture features,GLCM texture features
 global and local regression,Global And Local Regression
 global difference value,Global Difference Value
 global feature,Global Features
@@ -3914,47 +3274,28 @@ global information,Global Information
 Global Perceptual code,Global Perceptual Code
 Global recognition,Global Recognition
 Global shape description,Global Shape Description
-Global Slant,Global Slant
 global structure,Global Structure
-Global Visual Indices,Global Visual Indices
-Glossary,Glossary
 GloVe-vector representation,Glove-Vector Representation
-GLRL features,GLRL features
-GLVQ,GLVQ
-Glyph Class Map,Glyph Class Map
 Glyph embedding,Glyph Embedding
 Glyph extraction,Glyph Extraction
 Glyph separation,Glyph Separation
-Glyphs,Glyphs
-GMM,GMM
-GMM-HMM,GMM-HMM
-GMs,GMs
 GOAL-DRIVEN RECOGNITION,Goal-Driven Recognition
 good continuity criteria,Good Continuity Criteria
 GoogLeNet,GoogleNet
-GoogleNet,GoogleNet
 Governor-General of Taiwan,Governor-General Of Taiwan
-GPGPU,GPGPU
-GPU,GPU
-GPU code optimization,GPU code optimization
-Gradation,Gradation
 GRADE,Grade
 GRADES,Grades
 GRADIENT,Gradient
-Gradient,Gradient
 GRADIENT DESCENT,Gradient Descent
 gradient descriptor,Gradient Descriptor
 Gradient direction,Gradient Direction
 gradient direction feature,Gradient Direction Feature
-Gradient Directional Pattern,Gradient Directional Pattern
 Gradient feature,Gradient Features
 gradient feature,Gradient Features
-Gradient Features,Gradient Features
 Gradient features,Gradient Features
 gradient features,Gradient Features
 Gradient features descriptor,Gradient Features Descriptor
 Gradient Local Auto-correlation,Gradient Local Auto-Correlation
-Gradient Local Binary Patterns,Gradient Local Binary Patterns
 gradient local binary patterns,Gradient Local Binary Patterns
 gradient methods,Gradient Methods
 Gradient Structural Concavity (GSC),Gradient Structural Concavity
@@ -3963,10 +3304,8 @@ Gradient-based learning,Gradient-Based Learning
 gradient-based learning,Gradient-Based Learning
 gradient-based technique,Gradient-Based Technique
 gradually truncated partial products,Gradually Truncated Partial Products
-Graffiti,Graffiti
 Gramian Angular Field images,Gramian Angular Field Images
 GRAMMAR,Grammar
-Grammar,Grammar
 grammar,Grammar
 GRAMMARS,Grammar
 Grammatical evolution,Grammatical Evolution
@@ -3975,7 +3314,6 @@ grammatical sublexical units,Grammatical Sublexical Units
 Granular Soft Computing (GrSC),Granular Soft Computing
 granularity level,Granularity Level
 GRAPH,Graph
-Graph,Graph
 graph,Graph
 Graph attention networks,Graph Attention Networks
 graph based OCR,Graph Based OCR
@@ -3983,10 +3321,8 @@ Graph benchmarking dataset,Graph Benchmarking Dataset
 Graph classification,Graph Classification
 graph computation,Graph Computation
 GRAPH CUTS,Graph Cuts
-Graph Cuts,Graph Cuts
 Graph dissimilarity Space Embedding (GDSE),Graph Dissimilarity Space Embedding
 GRAPH EDIT DISTANCE,Graph Edit Distance
-Graph Edit Distance,Graph Edit Distance
 Graph edit distance,Graph Edit Distance
 graph edit distance,Graph Edit Distance
 Graph edit-distance,Graph Edit-Distance
@@ -3996,7 +3332,6 @@ Graph embedding into vector,Graph Embedding Into Vector
 Graph grammar,Graph Grammar
 graph grammar,Graph Grammar
 graph learning,Graph Learning
-Graph Matching,Graph Matching
 Graph matching,Graph Matching
 graph matching,Graph Matching
 graph matcing,Graph Matcing
@@ -4006,7 +3341,6 @@ Graph parsing,Graph Parsing
 graph partitioning,Graph Partitioning
 Graph repository,Graph Repository
 GRAPH REPRESENTATION,Graph Representation
-Graph Representation,Graph Representation
 Graph representation,Graph Representation
 Graph representation for handwritten words,Graph Representation For Handwritten Words
 graph theoretic approach,Graph Theoretic Approach
@@ -4015,7 +3349,6 @@ Graph transformation,Graph Transformation
 graph transformer networks,Graph Transformer Networks
 graph traversal,Graph Traversal
 GRAPHEME,Grapheme
-Grapheme,Grapheme
 grapheme,Grapheme
 Grapheme codebook,Grapheme Codebook
 Grapheme over-segmentation,Grapheme Over-Segmentation
@@ -4025,23 +3358,18 @@ GRAPHEMES SEGMENTATION,Grapheme Segmentation
 graphemes segmentation,Grapheme Segmentation
 grapheme-based approach,Grapheme-Based Approach
 grapheme-emission probability distribution,Grapheme-Emission Probability Distribution
-Graphemes,Graphemes
 graphemes,Graphemes
 graphic motor programs,Graphic Motor Programs
 graphic tablet,Graphic Tablet
 Graphical domain,Graphical Domain
 graphical domain,Graphical Domain
 graphical models,Graphical Models
-Graphical Symbol Discovery,Graphical Symbol Discovery
 Graphical symbol knowledge extraction,Graphical Symbol Knowledge Extraction
 Graphical symbol retrieval,Graphical Symbol Retrieval
 Graphical symbol spotting,Graphical Symbol Spotting
 GRAPHICS,Graphics
-Graphics Processing Unit,Graphics Processing Unit
-Graphics Recognition,Graphics Recognition
 Graphics recognition,Graphics Recognition
 graphics recognition,Graphics Recognition
-Graphology,Graphology
 Graphometric features,Graphometric Features
 grapho-motor planning,Grapho-Motor Planning
 Grapho-motor processes,Grapho-Motor Processes
@@ -4057,17 +3385,12 @@ Gray level Co-occurrence matrix,Gray Level Co-Occurrence Matrix
 Gray Level Co-occurrence Matrix (GLCM),Gray Level Co-Occurrence Matrix
 Grey-Level Co-occurrence Matrix (GLCM),Gray Level Co-Occurrence Matrix
 Gray level information,Gray Level Information
-Gray Level Run Length Matrices,Gray Level Run Length Matrices
-Gray Wolf Optimization,Gray Wolf Optimization
 Gray-level Normalization,Gray-Level Normalization
-Grayscale,Grayscale
 Grayscale conversio,Grayscale Conversion
 gray-scale handwritten character recognition,Gray-Scale Handwritten Character Recognition
 Green's function,Green's Function
 grey level co-occurrence matrix feature,Grey Level Co-Occurrence Matrix Feature
-Grey Level Handwritten Image Documents,Grey Level Handwritten Image Documents
 grey wolf optimization,Grey Wolf Optimization
-Grid,Grid
 grid code transformation,Grid Code Transformation
 grids,Grids
 GRIP,Grip
@@ -4083,36 +3406,19 @@ Group Method of Data Handling (GMDH),Group Method Of Data Handling
 Grouping of classes,Grouping Of Classes
 grouping of classes,Grouping Of Classes
 growing cell structure,Growing Cell Structure
-GRU,GRU
-GRUs,GRUs
-GSC,GSC
-GSC Features,GSC Features
 Guassian mass,Guassian Mass
 guessability,Guessability
-GUI,GUI
 Guideline removal,Guideline Removal
-Gujarati,Gujarati
 Gujarati character Recognition,Gujarati Character Recognition
-Gujarati Characters,Gujarati Characters
 Gujarati handwritten character recognition,Gujarati Handwritten Character Recognition
-Gurmukhi,Gurmukhi
 Gurmukhi characters,Gurmukhi Characters
-Gurmukhi Script,Gurmukhi Script
 Gurmukhi script,Gurmukhi Script
-Gurmukhi Strokes,Gurmukhi Strokes
-Gurmukhi Word,Gurmukhi Word
-Gurumukhi,Gurumukhi
 gyro sensor,Gyro Sensor
-Gyroscope,Gyroscope
 gyroscope,Gyroscope
 Gyroscopes,Gyroscope
-Haar Wavelet Decomposistion,Haar Wavelet Decomposistion
 Haar wavelet transfor,Haar Wavelet Transfor
-Habitoscopy,Habitoscopy
-HACDB,HACDB
 haemodynamics,Haemodynamics
 Hamiltonian path,Hamiltonian Path
-Hamming Distance,Hamming Distance
 HAND,Hand
 hand,Hand
 HAND GESTURE,Hand Gesture
@@ -4147,9 +3453,7 @@ handritten recognition,Handritten Recognition
 Handwriten digits,Handwriten Digits
 handwriter identification,Handwriter Identification
 HANDWRITING,Handwriting
-Handwriting,Handwriting
 handwriting,Handwriting
-Handwriting Analysis,Handwriting Analysis
 Handwriting analysis,Handwriting Analysis
 handwriting analysis,Handwriting Analysis
 handwriting analysis and generation,Handwriting Analysis And Generation
@@ -4170,10 +3474,8 @@ handwriting detection,Handwriting Detection
 handwriting difficulty,Handwriting Difficulty
 Handwriting digit recognition,Handwriting Digit Recognition
 Handwriting digit string recognition,Handwriting Digit String Recognition
-Handwriting Dynamics,Handwriting Dynamics
 handwriting examination,Handwriting Examination
 handwriting examiners,Handwriting Examiners
-Handwriting Features,Handwriting Features
 Handwriting features,Handwriting Features
 Handwriting fluency,Handwriting Fluency
 handwriting fluency,Handwriting Fluency
@@ -4188,7 +3490,6 @@ Handwriting identification,Handwriting Identification
 handwriting identification,Handwriting Identification
 Handwriting idiosyncrasy,Handwriting Idiosyncrasy
 handwriting image,Handwriting Image
-Handwriting Individuality,Handwriting Individuality
 Handwriting individuality,Handwriting Individuality
 handwriting input method,Handwriting Input Method
 Handwriting intervention,Handwriting Intervention
@@ -4212,7 +3513,6 @@ HANDWRITING PRODUCTION,Handwriting Production
 Handwriting quality evaluation,Handwriting Quality Evaluation
 Hand writing recognition,Handwriting Recognition
 HANDWRITING RECOGNITION,Handwriting Recognition
-Handwriting Recognition,Handwriting Recognition
 Handwriting recognition,Handwriting Recognition
 handwriting recognition,Handwriting Recognition
 Hand-writing recognition,Handwriting Recognition
@@ -4225,7 +3525,6 @@ handwriting recognition and interpretation,Handwriting Recognition And Interpret
 handwriting recognition competition,Handwriting Recognition Competition
 Handwriting recognition interactive television (TV),Handwriting Recognition Interactive Television
 HANDWRITING RECOGNITION SHAPE,Handwriting Recognition Shape
-Handwriting Recognition System,Handwriting Recognition System
 Handwriting recognition system,Handwriting Recognition System
 handwriting recognition system,Handwriting Recognition System
 Handwriting recognition technologies,Handwriting Recognition Technologies
@@ -4235,7 +3534,6 @@ HANDWRITING RESEARCH,Handwriting Research
 handwriting retrieval,Handwriting Retrieval
 handwriting samples,Handwriting Samples
 handwriting scripts,Handwriting Scripts
-Handwriting Segmentation,Handwriting Segmentation
 Handwriting segmentation,Handwriting Segmentation
 handwriting segmentation,Handwriting Segmentation
 Handwriting signature,Handwriting Signature
@@ -4245,10 +3543,8 @@ handwriting specialization,Handwriting Specialization
 Handwriting speed,Handwriting Speed
 handwriting style,Handwriting Style
 handwriting style-based features,Handwriting Style-Based Features
-Handwriting Synthesis,Handwriting Synthesis
 Handwriting synthesis,Handwriting Synthesis
 handwriting synthesis,Handwriting Synthesis
-Handwriting Test,Handwriting Test
 handwriting text line normalization,Handwriting Text Line Normalization
 Handwriting text recognition,Handwriting Text Recognition
 handwriting text recognition,Handwriting Text Recognition
@@ -4256,13 +3552,11 @@ handwriting to speech conversion,Handwriting To Speech Conversion
 handwriting tracking,Handwriting Tracking
 Handwriting training,Handwriting Training
 handwriting traits,Handwriting Traits
-Handwriting Trajectory Recovery,Handwriting Trajectory Recovery
 Handwriting verification,Handwriting Verification
 handwriting verification,Handwriting Verification
 Handwriting/machine print discrimination,Handwriting/Machine Print Discrimination
 hand written,Handwritten
 HANDWRITTEN,Handwritten
-Handwritten,Handwritten
 handwritten,Handwritten
 HAND-WRITTEN,Handwritten
 Hand-written,Handwritten
@@ -4272,16 +3566,10 @@ handwritten alphabets,Handwritten Alphabets
 Handwritten Amazigh recognition,Handwritten Amazigh Recognition
 handwritten answer,Handwritten Answer
 Handwritten answer book,Handwritten Answer Book
-Handwritten Answer Evaluation System,Handwritten Answer Evaluation System
-Handwritten Arabic,Handwritten Arabic
 handwritten Arabic,Handwritten Arabic
-Handwritten Arabic Character Recognition,Handwritten Arabic Character Recognition
 Handwritten Arabic Character Recognition (HACR),Handwritten Arabic Character Recognition
-Handwritten Arabic Database,Handwritten Arabic Database
 Handwritten Arabic database,Handwritten Arabic Database
-Handwritten Arabic Document,Handwritten Arabic Document
 Handwritten Arabic recognition,Handwritten Arabic Recognition
-Handwritten Arabic Script,Handwritten Arabic Script
 handwritten arabic script,Handwritten Arabic Script
 handwritten Arabic words,Handwritten Arabic Words
 handwritten assignment on Web,Handwritten Assignment On Web
@@ -4291,7 +3579,6 @@ Handwritten Bangla character recognition,Handwritten Bangla Character Recognitio
 handwritten Bangla character recognition,Handwritten Bangla Character Recognition
 Handwritten Bangla character recognition (HBCR),Handwritten Bangla Character Recognition
 Handwritten Bangla character,Handwritten Bangla Characters
-Handwritten Bangla Characters,Handwritten Bangla Characters
 Handwritten Bangla digit recognition,Handwritten Bangla Digit Recognition
 handwritten Bangla words,Handwritten Bangla Words
 handwritten biometric recognition,Handwritten Biometric Recognition
@@ -4305,7 +3592,6 @@ handwritten character patterns,Handwritten Character Patterns
 and handwritten character recognition,Handwritten Character Recognition
 Hand Written Character Recognition,Handwritten Character Recognition
 HANDWRITTEN CHARACTER RECOGNITION,Handwritten Character Recognition
-Handwritten Character Recognition,Handwritten Character Recognition
 Handwritten Character recognition,Handwritten Character Recognition
 Handwritten character recognition,Handwritten Character Recognition
 handwritten character recognition,Handwritten Character Recognition
@@ -4334,7 +3620,6 @@ handwritten chess dataset,Handwritten Chess Dataset
 handwritten Chinese,Handwritten Chinese
 Handwritten Chinese address recognition,Handwritten Chinese Address Recognition
 handwritten Chinese and Japanese character,Handwritten Chinese And Japanese Character
-Handwritten Chinese Character Recognition,Handwritten Chinese Character Recognition
 Handwritten Chinese character recognition,Handwritten Chinese Character Recognition
 handwritten Chinese character recognition,Handwritten Chinese Character Recognition
 handwritten Chinese character recognition (HCCR),Handwritten Chinese Character Recognition
@@ -4348,7 +3633,6 @@ Handwritten Chinese recognition,Handwritten Chinese Recognition
 handwritten Chinese text,Handwritten Chinese Text
 Handwritten Chinese text detection,Handwritten Chinese Text Detection
 Handwritten Chinese text editing,Handwritten Chinese Text Editing
-Handwritten Chinese Text Recognition,Handwritten Chinese Text Recognition
 Handwritten Chinese text recognition,Handwritten Chinese Text Recognition
 handwritten Chinese text recognition,Handwritten Chinese Text Recognition
 Handwritten Chinese word samples,Handwritten Chinese Word Samples
@@ -4361,17 +3645,14 @@ Handwritten Devanagari document,Handwritten Devanagari Document
 handwritten Devanagari words,Handwritten Devanagari Words
 handwritten diagram,Handwritten Diagram
 Hand-written diagram,Handwritten Diagram
-Handwritten Digit Classification,Handwritten Digit Classification
 Handwritten Digit classification,Handwritten Digit Classification
 handwritten digit database,Handwritten Digit Database
 HANDWRITTEN DIGIT RECOGNITION,Handwritten Digit Recognition
-Handwritten Digit Recognition,Handwritten Digit Recognition
 Handwritten digit recognition,Handwritten Digit Recognition
 handwritten digit recognition,Handwritten Digit Recognition
 Handwritten Digits Recognition,Handwritten Digit Recognition
 Handwritten digits recognition,Handwritten Digit Recognition
 handwritten digit recognition model experiment,Handwritten Digit Recognition Model Experiment
-Handwritten Digit Segmentation,Handwritten Digit Segmentation
 Handwritten digit string recognition,Handwritten Digit String Recognition
 handwritten digit string recognition,Handwritten Digit String Recognition
 Handwritten digit/outlier discrimination,Handwritten Digit/Outlier Discrimination
@@ -4382,10 +3663,8 @@ handwritten digits,Handwritten Digits
 Hand-written digits,Handwritten Digits
 handwritten digits and lowercase characters recognition,Handwritten Digits And Lowercase Characters Recognition
 Handwritten digits and signs,Handwritten Digits And Signs
-Handwritten Document,Handwritten Document
 Handwritten document,Handwritten Document
 handwritten document,Handwritten Document
-Handwritten Document Analysis,Handwritten Document Analysis
 Handwritten document analysis,Handwritten Document Analysis
 handwritten document analysis,Handwritten Document Analysis
 Handwritten documents analysis,Handwritten Document Analysis
@@ -4405,37 +3684,28 @@ Handwritten Document preprocessing,Handwritten Document Preprocessing
 handwritten document security,Handwritten Document Security
 hand written documents,Handwritten Documents
 HANDWRITTEN DOCUMENTS,Handwritten Documents
-Handwritten Documents,Handwritten Documents
 Handwritten documents,Handwritten Documents
 handwritten documents,Handwritten Documents
 Hand-written documents,Handwritten Documents
 Handwritten dynamics,Handwritten Dynamics
 handwritten dynamics,Handwritten Dynamics
-Handwritten English Word Recognition,Handwritten English Word Recognition
 handwritten English words,Handwritten English Words
 handwritten Farsi word recognition,Handwritten Farsi Word Recognition
 Handwritten features,Handwritten Features
 handwritten from machine-printed discrimination,Handwritten From Machine-Printed Discrimination
-Handwritten Gesture Classifier,Handwritten Gesture Classifier
 Handwritten gesture command recognition,Handwritten Gesture Command Recognition
 handwritten gesture recognition,Handwritten Gesture Recognition
-Handwritten Graphs,Handwritten Graphs
 Handwritten Hangul recognition,Handwritten Hangul Recognition
 Handwritten hangul recognition,Handwritten Hangul Recognition
 Handwritten historical manuscripts,Handwritten Historical Manuscripts
 handwritten images,Handwritten Images
 Handwritten Indic scripts,Handwritten Indic Scripts
 handwritten japanese character recognition,Handwritten Japanese Character Recognition
-Handwritten Japanese Text Recognition,Handwritten Japanese Text Recognition
 HANDWRITTEN KANJI RECOGNITION,Handwritten Kanji Recognition
 Handwritten Kannada alphabets,Handwritten Kannada Alphabets
 Handwritten kannada character recognition,Handwritten Kannada Character Recognition
-Handwritten Kannada Characters,Handwritten Kannada Characters
-Handwritten Kannada Word,Handwritten Kannada Word
-Handwritten Keyword Spotting,Handwritten Keyword Spotting
 Handwritten keyword spotting,Handwritten Keyword Spotting
 handwritten keyword spotting,Handwritten Keyword Spotting
-Handwritten Letter Recognition,Handwritten Letter Recognition
 handwritten letter recognition,Handwritten Letter Recognition
 handwritten mail,Handwritten Mail
 Handwritten manuscripts,Handwritten Manuscripts
@@ -4449,16 +3719,10 @@ handwritten mathematical expression,Handwritten Mathematical Expressions
 HANDWRITTEN MATHEMATICAL EXPRESSIONS,Handwritten Mathematical Expressions
 handwritten mathematical expressions,Handwritten Mathematical Expressions
 Handwritten mathematical symbols and&nbsp,Handwritten Mathematical Symbols
-Handwritten Mizo Characters,Handwritten Mizo Characters
-Handwritten Multilingual Documents,Handwritten Multilingual Documents
-Handwritten Music Recognition,Handwritten Music Recognition
 Handwritten music recognition,Handwritten Music Recognition
 handwritten music recognition,Handwritten Music Recognition
 handwritten music score recognition,Handwritten Music Score Recognition
-Handwritten Music Scores,Handwritten Music Scores
 Handwritten musical scores,Handwritten Music Scores
-Handwritten Music Scores Analysis,Handwritten Music Scores Analysis
-Handwritten Music Symbols,Handwritten Music Symbols
 handwritten notes,Handwritten Notes
 HANDWRITTEN NUMERALS,Handwritten Numeral
 handwritten numerals,Handwritten Numeral
@@ -4477,25 +3741,21 @@ Handwritten Persian characters recognition,Handwritten Persian Characters Recogn
 Handwritten Pinyin dataset,Handwritten Pinyin Dataset
 handwritten postal address recognition,Handwritten Postal Address Recognition
 handwritten receipt,Handwritten Receipt
-Handwritten Recognition,Handwritten Recognition
 Handwritten recognition,Handwritten Recognition
 handwritten Recognition,Handwritten Recognition
 handwritten recognition,Handwritten Recognition
 Handwritten Russian and Kazakh text recognition,Handwritten Russian And Kazakh Text Recognition
 Handwritten samples,Handwritten Samples
 Handwritten script,Handwritten Script
-Handwritten Script Identification,Handwritten Script Identification
 Handwritten script identification,Handwritten Script Identification
 handwritten script identification,Handwritten Script Identification
 Handwritten script recognition,Handwritten Script Recognition
 Handwritten scripts,Handwritten Scripts
-Handwritten Segmentation,Handwritten Segmentation
 HANDWRITTEN SIGNATURE RECOGNITION,Handwritten Signature Recognition
 Handwritten signature recognition,Handwritten Signature Recognition
 handwritten signature recognition,Handwritten Signature Recognition
 handwritten signature synthesis,Handwritten Signature Synthesis
 HANDWRITTEN SIGNATURE VERIFICATION,Handwritten Signature Verification
-Handwritten Signature Verification,Handwritten Signature Verification
 handwritten signature verification,Handwritten Signature Verification
 handwritten signatures verification,Handwritten Signature Verification
 handwritten signature-based identification,Handwritten Signature-Based Identification
@@ -4507,12 +3767,10 @@ Handwritten steel billet identification number,Handwritten Steel Billet Identifi
 handwritten stroke analysis,Handwritten Stroke Analysis
 HANDWRITTEN STROKES,Handwritten Strokes
 handwritten strokes,Handwritten Strokes
-Handwritten Symbol,Handwritten Symbol
 handwritten symbol recognition,Handwritten Symbol Recognition
 Handwritten Tamil character,Handwritten Tamil Character
 hand written text,Handwritten Text
 HANDWRITTEN TEXT,Handwritten Text
-Handwritten Text,Handwritten Text
 Handwritten text,Handwritten Text
 handwritten text,Handwritten Text
 hand-written text,Handwritten Text
@@ -4524,7 +3782,6 @@ handwritten text extraction,Handwritten Text Extraction
 Handwritten text generation,Handwritten Text Generation
 handwritten text image recognition,Handwritten Text Image Recognition
 handwritten text IR,Handwritten Text Image Recognition
-Handwritten Text Images,Handwritten Text Images
 handwritten text line recognition,Handwritten Text Line Recognition
 Handwritten text line segmentation,Handwritten Text Line Segmentation
 Hand-written text localization,Hand-Written Text Localization
@@ -4532,7 +3789,6 @@ HANDWRITTEN TEXT PROCESSING,Handwritten Text Processing
 Hand written text recognition,Handwritten Text Recognition
 hand written text recognition,Handwritten Text Recognition
 HANDWRITTEN TEXT RECOGNITION,Handwritten Text Recognition
-Handwritten Text Recognition,Handwritten Text Recognition
 Handwritten text Recognition,Handwritten Text Recognition
 Handwritten text recognition,Handwritten Text Recognition
 handwritten text recognition,Handwritten Text Recognition
@@ -4542,7 +3798,6 @@ Handwritten text recognition (HTR),Handwritten Text Recognition
 Handwritten text segmentation,Handwritten Text Segmentation
 handwritten text segmentation,Handwritten Text Segmentation
 handwritten text transcription,Handwritten Text Transcription
-Handwritten Tifinagh Characters,Handwritten Tifinagh Characters
 HANDWRITTEN WORD,Handwritten Word
 Handwritten word,Handwritten Word
 HANDWRITTEN WORD RECOGNITION,Handwritten Word Recognition
@@ -4559,7 +3814,6 @@ HANDWRITTEN WORDS MODELING,Handwritten Words Modeling
 handwritten/print identification,Handwritten/Print Identification
 Handwritten/printed receipt classification,Handwritten/Printed Receipt Classification
 handwritting,Handwritting
-Handwritting Recognition,Handwritting Recognition
 Handwrriting recognition,Handwrriting Recognition
 handy input,Handy Input
 HANGUL CHARACTER RECOGNITION,Hangul Character Recognition
@@ -4570,8 +3824,6 @@ haptic desktop interface,Haptic Desktop Interface
 haptic voice recognition,Haptic Voice Recognition
 Hard stroke features,Hard Stroke Features
 HARDWARE,Hardware
-Hardware Acceleration,Hardware Acceleration
-Hardware Architecture,Hardware Architecture
 Hardware architecture,Hardware Architecture
 hardware descriptions,Hardware Descriptions
 hardware design,Hardware Design
@@ -4582,48 +3834,31 @@ hardware performance,Hardware Performance
 HARMONY SEARCH,Harmony Search
 Harmony search,Harmony Search
 HARMONY SEARCH ALGORITHM,Harmony Search Algorithm
-Harmony Search Algorithm,Harmony Search Algorithm
 Harmony search algorithm,Harmony Search Algorithm
 Harris key-point detector,Harris Key-Point Detector
 Hartley transform,Hartley Transform
 Hash value,Hash Value
 hashing,Hashing
-Hastaprati,Hastaprati
 Hausdorff distance,Hausdorff Distance
-Hausdorff Edit Distance,Hausdorff Edit Distance
-HCD,HCD
-HCI,HCI
-HCRaaS,HCRaaS
-HCRF,HCRF
-HCTR,HCTR
-HDF5 dataset,HDF5 dataset
 H-DIBCO,H-Dibco
 HDL models,Hdl Models
 headline,Headline
 HEALTH,Health
 health,Health
-Health Care,Health Care
 Health care,Health Care
 health care sector,Health Care Sector
-Health Informatics,Health Informatics
-Healthcare,Healthcare
 HEALTH-CARE,Healthcare
 HEALTHY-SUBJECTS,Healthy-Subjects
 HEARING,Hearing
 Hearing impaired,Hearing Impaired
-Hebbian,Hebbian
-Hebbian Learning,Hebbian Learning
-Hebrew,Hebrew
 Hebrew handwritten documents,Hebrew Handwritten Documents
 HELP FIELDS,Help Fields
 HEMIANOPIA,Hemianopia
 HERMITE,Hermite
-Hermite,Hermite
 Heterogeneous architectures,Heterogeneous Architectures
 heterogeneous data,Heterogeneous Data
 heterogeneous documents,Heterogeneous Documents
 Heterogeneous layout,Heterogeneous Layout
-Heteroscedasticity,Heteroscedasticity
 Heuristic algorithms,Heuristic Algorithms
 Heuristic classifier,Heuristic Classifier
 heuristic evaluation for children,Heuristic Evaluation For Children
@@ -4633,17 +3868,12 @@ heuristic over-segmentation,Heuristic Over-Segmentation
 heuristic rules,Heuristic Rules
 heuristics,Heuristics
 HIDDEN,Hidden
-Hidden Conditional Random Fields,Hidden Conditional Random Fields
 hidden conditional random fields,Hidden Conditional Random Fields
-Hidden Layer,Hidden Layer
-Hidden Layers,Hidden Layers
-Hidden Markot Model,Hidden Markot Model
 hidden Markov mesh random field (HMMRF),Hidden Markov Mesh Random Field
 Hidden Markor Model (HMM),Hidden Markov Model
 Hidden markov modal (HMM),Hidden Markov Model
 hidden Markov mode,Hidden Markov Model
 HIDDEN MARKOV MODEL,Hidden Markov Model
-Hidden Markov Model,Hidden Markov Model
 Hidden Markov model,Hidden Markov Model
 Hidden markov model,Hidden Markov Model
 hidden Markov Model,Hidden Markov Model
@@ -4670,22 +3900,17 @@ HMM,Hidden Markov Model
 HMMS,Hidden Markov Model
 HMMs,Hidden Markov Model
 Hidden Markov Model (HMM) and Machine Learning,Hidden Markov Model And Machine Learning
-Hidden Markov Model Emission Probability,Hidden Markov Model Emission Probability
 Hidden semi-Markov model (HSMM),Hidden Semi-Markov Model
 Hidden unit,Hidden Unit
 hierarchical Bayesian models,Hierarchical Bayesian Models
 Hierarchical Bayesian network,Hierarchical Bayesian Network
 Hierarchical character clustering,Hierarchical Character Clustering
 hierarchical character representation,Hierarchical Character Representation
-Hierarchical Classification,Hierarchical Classification
 Hierarchical classification,Hierarchical Classification
 hierarchical classification,Hierarchical Classification
-Hierarchical Clustering,Hierarchical Clustering
 hierarchical clustering,Hierarchical Clustering
-Hierarchical CNN,Hierarchical CNN
 hierarchical CNN model,Hierarchical CNN
 Hierarchical convolutional neural network,Hierarchical CNN
-Hierarchical Deep Neural Network,Hierarchical Deep Neural Network
 Hierarchical description,Hierarchical Description
 hierarchical display,Hierarchical Display
 hierarchical fusion,Hierarchical Fusion
@@ -4726,10 +3951,8 @@ highly reliable classifier,Highly Reliable Classifier
 High-order Markov random field,High-Order Markov Random Field
 HIGH-PERFORMANCE,High-Performance
 high-quality digitising tablets,High-Quality Digitising Tablets
-Hijja Dataset,Hijja Dataset
 Hijja dataset,Hijja Dataset
 Hilbert transforms,Hilbert Transforms
-Hindi,Hindi
 Hindi character recognition,Hindi Character Recognition
 hindi character recognition,Hindi Character Recognition
 hindi handwritten,Hindi Handwritten
@@ -4737,11 +3960,8 @@ Hindi language,Hindi Language
 numerals Hindi numerals,Hindi Numerals
 Hindi signatures,Hindi Signatures
 Hindi text entry,Hindi Text Entry
-HIP,HIP
-Hippocampus,Hippocampus
 hiragana character recognition,Hiragana Character Recognition
 HISTOGRAM,Histogram
-Histogram,Histogram
 histogram,Histogram
 HISTOGRAMS,Histogram
 histograms,Histogram
@@ -4764,18 +3984,15 @@ Histogram of Oriented Pixel Positions (HOPP),Histogram Of Oriented Pixel Positio
 histogram oriented gabor gradient feature,Histogram Oriented Gabor Gradient Feature
 Histogram profile,Histogram Profile
 Histogram projection profile,Histogram Projection Profile
-Histogram Symbolic Representation,Histogram Symbolic Representation
 historic documents,Historic Documents
 historical,Historical
 Historical Arabic handwriting,Historical Arabic Handwriting
 historical Arabic manuscript dating,Historical Arabic Manuscript Dating
 historical data,Historical Data
-Historical Document Analysis,Historical Document Analysis
 Historical document analysis,Historical Document Analysis
 historical document analysis,Historical Document Analysis
 Historical document dating,Historical Document Dating
 historical document dating,Historical Document Dating
-Historical Document Image,Historical Document Image
 historical document image processing,Historical Document Image Processing
 Historical document image retrieval,Historical Document Image Retrieval
 historical document localization,Historical Document Localization
@@ -4786,7 +4003,6 @@ Historical Document,Historical Documents
 Historical document,Historical Documents
 historical document,Historical Documents
 HISTORICAL DOCUMENTS,Historical Documents
-Historical Documents,Historical Documents
 Historical documents,Historical Documents
 historical Documents,Historical Documents
 historical documents,Historical Documents
@@ -4802,7 +4018,6 @@ historical handwritten transcription,Historical Handwritten Transcription
 historical image processing,Historical Image Processing
 historical images,Historical Images
 Historical manuscript analysis,Historical Manuscript Analysis
-Historical Manuscripts,Historical Manuscripts
 Historical manuscripts,Historical Manuscripts
 historical manuscripts,Historical Manuscripts
 HISTORICAL REVIEW,Historical Review
@@ -4813,15 +4028,11 @@ Historical vietnamese steles,Historical Vietnamese Steles
 historical weather logs,Historical Weather Logs
 history,History
 hit-miss transform,Hit-Miss Transform
-HIT-OR3C,HIT-OR3C
-HLH pattern,HLH pattern
-HMAX,HMAX
 HMM adaptation,HMM Adaptation
 HMM based handwriting recognition,HMM Based Handwriting Recognition
 HMM Bayesian adaptation,HMM Bayesian Adaptation
 HMM maximum A posteriori adaptation,HMM Maximum A Posteriori Adaptation
 HMM maximum likelihood adaptation,HMM Maximum Likelihood Adaptation
-HMM Model,HMM Model
 HMM model quality,HMM Model Quality
 HMM structure learning,HMM Structure Learning
 HMM Toolkit (HTK),HMM Toolkit
@@ -4830,7 +4041,6 @@ HMM-BASED APPROACH,HMM-Based Approach
 HMM-based handwriting recognition,HMM-Based Handwriting Recognition
 HMM-based system,HMM-Based System
 HMM-SVM classifier thresholding,Hmm-Svm Classifier Thresholding
-HOCR,HOCR
 Hoeffding tree,Hoeffding Tree
 HOG descriptor,Hog Descriptor
 hole-filler template,Hole-Filler Template
@@ -4851,33 +4061,22 @@ HOLOGRAPHIC REPRESENTATION OF IMAGES,Holographic Representation Of Images
 HOLOGRAPHS,Holographs
 Holy Quran text image,Holy Quran Text Image
 homogeneous transformation matrices,Homogeneous Transformation Matrices
-HOMUS dataset,HOMUS dataset
 HONG-KONG,Hong-Kong
-Hopfield Network,Hopfield Network
 Hopfield network,Hopfield Network
 HOPFIELD NEURAL NETWORK,Hopfield Neural Network
-Hopfield Neural Network,Hopfield Neural Network
 Hopfield neural network,Hopfield Neural Network
 horizontal and vertical feedback,Horizontal And Vertical Feedback
 Horizontal and vertical trajectories,Horizontal And Vertical Trajectories
-Horizontal Projection,Horizontal Projection
 horizontal projection profile,Horizontal Projection Profile
 Horizontal segmentation,Horizontal Segmentation
 horizontal text,Horizontal Text
 Hospital discharge,Hospital Discharge
 Hospital information systems,Hospital Information Systems
 hospital organization and administration,Hospital Organization And Administration
-Hospitals,Hospitals
 HOUGH TRANSFORM,Hough Transform
-Hough Transform,Hough Transform
 Hough transform,Hough Transform
 hough transform,Hough Transform
 HOUGH-TRANSFORM,Hough Transform
-Hough Transformation,Hough Transformation
-HP-Labs-India's Telugu character dataset,HP-Labs-India's Telugu character dataset
-HRNN,HRNN
-HTK toolkit,HTK toolkit
-HTR,HTR
 Hu moments,Hu Moments
 hu moments,Hu Moments
 Hull regions,Hull Regions
@@ -4886,13 +4085,11 @@ HUMAN BRAIN,Human Brain
 Human centered automation,Human Centered Automation
 HUMAN CEREBRAL-CORTEX,Human Cerebral-Cortex
 Human computation,Human Computation
-Human Computer Interaction,Human Computer Interaction
 Human computer interaction,Human Computer Interaction
 human computer interaction,Human Computer Interaction
 HUMAN CONNECTOME PROJECT,Human Connectome Project
 human experts,Human Experts
 human handwriting distortion,Human Handwriting Distortion
-Human Handwriting Recognition,Human Handwriting Recognition
 HUMAN HISTORY,Human History
 Human interaction,Human Interaction
 Human Interactive Proof (HIP),Human Interactive Proof
@@ -4906,7 +4103,6 @@ Human vision,Human Vision
 human vision,Human Vision
 computer interaction (HCI),Human-Computer Interaction
 HUMAN-COMPUTER INTERACTION,Human-Computer Interaction
-Human-Computer Interaction,Human-Computer Interaction
 Human-computer Interaction,Human-Computer Interaction
 Human-computer interaction,Human-Computer Interaction
 human-computer interaction,Human-Computer Interaction
@@ -4929,11 +4125,8 @@ human-robot interactions,Human-Robot Interaction
 HUMANS,Humans
 Hungarian method,Hungarian Method
 Hu's seven moments,Hu's Seven Moments
-HWCR,HWCR
 H-WordNet model,H-Wordnet Model
-HWR,HWR
 HYBRID,Hybrid
-Hybrid,Hybrid
 hybrid ANN/HMM system,Hybrid Ann/Hmm System
 hybrid approach,Hybrid Approach
 Hybrid approach for offline Telugu character recognition,Hybrid Approach For Offline Telugu Character Recognition
@@ -4944,14 +4137,9 @@ hybrid classifier,Hybrid Classifier
 Hybrid decision system (HDS),Hybrid Decision System
 Hybrid deep architecture,Hybrid Deep Architecture
 Hybrid Deep Learning (HDL),Hybrid Deep Learning
-Hybrid Evolutionary Algorithm,Hybrid Evolutionary Algorithm
-Hybrid Feature Extraction,Hybrid Feature Extraction
 hybrid feature extraction,Hybrid Feature Extraction
 hybrid feature fusion,Hybrid Feature Fusion
 hybrid fusion approach,Hybrid Fusion Approach
-hybrid HMM,hybrid HMM
-hybrid HMM/ANN,hybrid HMM/ANN
-Hybrid HMM/ANN models,Hybrid HMM/ANN models
 Hybrid language model,Hybrid Language Model
 hybrid language model,Hybrid Language Model
 hybrid learning,Hybrid Learning
@@ -4964,16 +4152,13 @@ hybrid models,Hybrid Model
 hybrid modeling,Hybrid Modeling
 hybrid networks,Hybrid Networks
 Hybrid neural models,Hybrid Neural Models
-Hybrid OCR,Hybrid OCR
 Hybrid recognition system,Hybrid Recognition System
 hybrid recognizer,Hybrid Recognizer
 Hybrid Segmentation Technique for isolated character,Hybrid Segmentation Technique For Isolated Character
 hybrid systems,Hybrid Systems
 Hybridization techniques,Hybridization Techniques
 HYPERACTIVITY,Hyperactivity
-Hyperline Segment,Hyperline Segment
 hyperline segment,Hyperline Segment
-Hyperlinking,Hyperlinking
 Hyper-parameters Optimization,Hyperparameters Optimization
 HYPERPARATHYROIDISM,Hyperparathyroidism
 hyperplane separation,Hyperplane Separation
@@ -4985,17 +4170,6 @@ Hyphenated words,Hyphenated Words
 hypobaric chamber,Hypobaric Chamber
 hypothesis testing,Hypothesis Testing
 hypothesis-driven approaches,Hypothesis-Driven Approaches
-I2GNG,I2GNG
-I2GNG-Clonclas,I2GNG-Clonclas
-"i3zJL-1,PQ","i3zJL-1,PQ"
-IAM,IAM
-IAM database,IAM database
-IAM dataset,IAM dataset
-IAM English dataset,IAM English dataset
-IAM handwriting database,IAM handwriting database
-IAM On-Line Handwriting Database,IAM On-Line Handwriting Database
-IBN SINA database,IBN SINA database
-ICA,ICA
 ICDAR competition,ICDAR Competition
 ICDAR2013 handwritten segmentation contest data set,ICDAR2013 Handwritten Segmentation Contest Data Set
 ICDAR-2013 offline HCCR datasets,ICDAR2013 Offline Hccr Datasets
@@ -5004,11 +4178,8 @@ ICEHR'16 Contest,ICEHR16 Contest
 ICFHR2012 COMPETITION,ICFHR2012 Competition
 ICFHR2018 competition,ICFHR2018 Competition
 Iconic gestures,Iconic Gestures
-ICR,ICR
 ICR cells,ICR Cells
-ICZ plus ZCZ feature,ICZ plus ZCZ feature
 IDENTIFICATION,Identification
-Identification,Identification
 Identification of person,Identification Of Person
 identified pseudocharacters,Identified Pseudocharacters
 Identifying the Cause of Misrecognition,Identifying The Cause Of Misrecognition
@@ -5016,33 +4187,21 @@ identifying writer,Identifying Writer
 IDENTITY,Identity
 identity verification,Identity Verification
 idiosyncratic responses,Idiosyncratic Responses
-IFN,IFN
-IFN/ENIT,IFN/ENIT
 Institut fur Nachrichtentechnik/Ecole Nationale d'Ingenieurs de Tunis (IFN/ENIT),IFN/ENIT
-IFN/ENIT database,IFN/ENIT database
 IfN/ENIT Database,IFN/ENIT database
 IFN/ENIT-database,IFN/ENIT database
-IFN-Farsi dataset,IFN-Farsi dataset
-IFNIENIT databases,IFNIENIT databases
-IIIF,IIIF
-ILBP,ILBP
-ILP,ILP
 IMAGE,Image
 image,Image
 IMAGE ACQUISITION,Image Acquisition
 IMAGE ANALYSIS,Image Analysis
-Image Analysis,Image Analysis
 image analysis,Image Analysis
 image annotation,Image Annotation
-Image Arithmetic,Image Arithmetic
-Image Binarization,Image Binarization
 Image binarization,Image Binarization
 image binarization,Image Binarization
 Image capture,Image Capture
 image categorization,Image Categorization
 image characteristics,Image Characteristics
 IMAGE CLASSIFICATION,Image Classification
-Image Classification,Image Classification
 Image classification,Image Classification
 image classification,Image Classification
 Image classififcation,Image Classififcation
@@ -5050,7 +4209,6 @@ Image coding,Image Coding
 image coding,Image Coding
 image component fractal dimension,Image Component Fractal Dimension
 image compression,Image Compression
-Image Contrast,Image Contrast
 Image data analysis,Image Data Analysis
 IMAGE DATABASE,Image Database
 Image database,Image Database
@@ -5062,13 +4220,11 @@ Image document analysis,Image Document Analysis
 IMAGE ENCRYPTION,Image Encryption
 Image enhancement,Image Enhancement
 image enhancement,Image Enhancement
-Image Entropy,Image Entropy
 image feature,Image Feature
 Image feature extraction,Image Feature Extraction
 image feature extraction,Image Feature Extraction
 image forensics,Image Forensics
 image fusion,Image Fusion
-Image Generation,Image Generation
 Image generation,Image Generation
 image indexing,Image Indexing
 image interpretation,Image Interpretation
@@ -5081,16 +4237,13 @@ image preprocessing,Image Preprocessing
 Image pre-processing,Image Preprocessing
 Image process,Image Process
 IMAGE PROCESSING,Image Processing
-Image Processing,Image Processing
 Image processing,Image Processing
 image processing,Image Processing
 image processing and computer vision,Image Processing And Computer Vision
 Image Processing and Understanding,Image Processing And Understanding
 image processing and understanding,Image Processing And Understanding
-Image Processing Techniques,Image Processing Techniques
 image pyramids,Image Pyramids
 IMAGE RECOGNITION,Image Recognition
-Image Recognition,Image Recognition
 Image recognition,Image Recognition
 image recognition,Image Recognition
 Image reconstruction,Image Reconstruction
@@ -5101,19 +4254,15 @@ image representation,Image Representation
 Image restoration,Image Restoration
 image restoration,Image Restoration
 IMAGE RETRIEVAL,Image Retrieval
-Image Retrieval,Image Retrieval
 Image retrieval,Image Retrieval
 image retrieval,Image Retrieval
-Image Scaling,Image Scaling
 IMAGE SEGMENTATION,Image Segmentation
-Image Segmentation,Image Segmentation
 Image segmentation,Image Segmentation
 image segmentation,Image Segmentation
 Image segmentation method,Image Segmentation Method
 image sensors,Image Sensors
 Image signature,Image Signature
 Image space,Image Space
-Image Sudoku Solver,Image Sudoku Solver
 Image superimposition,Image Superimposition
 Image text translation,Image Text Translation
 image texture,Image Texture
@@ -5123,9 +4272,7 @@ image thresholding,Image Thresholding
 Image to Text,Image To Text
 Image to text converter,Image To Text Converter
 IMAGE TRANSFORMATION,Image Transformation
-Image Transformations,Image Transformations
 Image understanding,Image Understanding
-Image Vectors,Image Vectors
 Image warping,Image Warping
 IMAGE-ANALYSIS,Image-Analysis
 IMAGED TEXT,Imaged Text
@@ -5137,18 +4284,14 @@ IMAGING EVIDENCE,Imaging Evidence
 imaging processing,Imaging Processing
 imaging radar,Imaging Radar
 imbalanced learning data,Imbalanced Learning Data
-IMEI number,IMEI number
 IMITATION,Imitation
-IMLDA,IMLDA
 IMPACT,Impact
 IMPAIRMENT,Impairment
 IMPLEMENTATION,Implementation
 IMPLICIT,Implicit
 Implicit segmentation,Implicit Segmentation
 Implicit shape codebook,Implicit Shape Codebook
-Imprecision,Imprecision
 IMPROVE,Improve
-improved BP neural network,improved BP neural network
 improved elastic matching,Improved Elastic Matching
 improved LeNet-5 model,Improved Lenet-5 Model
 Improved VGG16 model,Improved Vgg16 Model
@@ -5156,7 +4299,6 @@ IMPROVEMENT,Improvement
 Improving classroom teaching,Improving Classroom Teaching
 IMPROVING HANDWRITING RECOGNIZERS,Improving Handwriting Recognizers
 IMPROVING RECOGNITION,Improving Recognition
-IMU,IMU
 In-air handwriting,In-Air Handwriting
 In-air handwriting recognition,In-Air Handwriting Recognition
 in-air handwriting recognition based on inertial sensors,In-Air Handwriting Recognition Based On Inertial Sensors
@@ -5168,7 +4310,6 @@ Incidental self-processing,Incidental Self-Processing
 incomplete seed character set,Incomplete Seed Character Set
 Incremental Input Dimensionality method,Incremental Input Dimensionality Method
 INCREMENTAL LEARNING,Incremental Learning
-Incremental Learning,Incremental Learning
 Incremental learning,Incremental Learning
 incremental learning,Incremental Learning
 Incremental learning of RBF-NN,Incremental Learning Of Rbf-Nn
@@ -5181,17 +4322,14 @@ INDEPENDENT WRITER IDENTIFICATION,Independent Writer Identification
 INDEX,Index
 INDEXES,Index
 Index terms-handwriting,Index Terms-Handwriting
-Indexing,Indexing
 indexing,Indexing
 Indian language,Indian Language
 Indian postal automation,Indian Postal Automation
 Indian regional scripts,Indian Regional Scripts
-Indian Script,Indian Script
 Indian script,Indian Script
 Indian script character recognition,Indian Script Character Recognition
 Indian script handwriting recognition,Indian Script Handwriting Recognition
 Indian script identification,Indian Script Identification
-Indian Script Recognition,Indian Script Recognition
 Indian script-based OCR system,Indian Script-Based OCR System
 INDIAN SCRIPTS,Indian Scripts
 Indian scripts,Indian Scripts
@@ -5200,7 +4338,6 @@ Indic and non-indic scripts,Indic And Non-Indic Scripts
 Indic script,Indic Script
 Indic scripts,Indic Script
 Indic script identification,Indic Script Identification
-Indic Text Recognition,Indic Text Recognition
 indic/arabic/asian scripts,Indic/Arabic/Asian Scripts
 INDIVIDUAL-DIFFERENCES,Individual-Differences
 individualistic styles,Individualistic Styles
@@ -5212,7 +4349,6 @@ INDUCTIVE LEARNING,Inductive Learning
 inductive logic programming,Inductive Logic Programming
 industrial application,Industrial Application
 Industrial informatics,Industrial Informatics
-Industry 4.0,Industry 4.0
 Inertial measurement unit,Inertial Measurement Unit
 inertial navigation system,Inertial Navigation System
 Inertial pen,Inertial Pen
@@ -5235,7 +4371,6 @@ Information extraction,Information Extraction
 information extraction,Information Extraction
 Information fusion,Information Fusion
 information fusion,Information Fusion
-Information Fusion Techniques,Information Fusion Techniques
 information integration,Information Integration
 information processing,Information Processing
 Information retrieval,Information Retrieval
@@ -5244,7 +4379,6 @@ Information security,Information Security
 information security,Information Security
 Information systems,Information Systems
 INFORMATION TECHNOLOGY,Information Technology
-Information Theory,Information Theory
 Information theory,Information Theory
 informative feature,Informative Feature
 infrared image,Infrared Image
@@ -5253,22 +4387,17 @@ inhibition,Inhibition
 INJECTION,Injection
 Injections,Injection
 INK,Ink
-Ink,Ink
 ink,Ink
 ink deposition model,Ink Deposition Model
 ink stroke classification,Ink Stroke Classification
 inkball models,Inkball Models
 InkCollector,Inkcollector
 InkOverlay,Inkoverlay
-In-Memory Computation,In-Memory Computation
 in-memory computing,In-Memory Computing
-Innovation,Innovation
-Inpainting,Inpainting
 INPUT,Input
 input device,Input Device
 INPUT DEVICES,Input Devices
 input devices and strategies,Input Devices And Strategies
-Input Gesture,Input Gesture
 input medium,Input Medium
 Input REPRE$sentation,Input Repre$Sentation
 INPUT SPACE REPRESENTATION,Input Space Representation
@@ -5278,14 +4407,12 @@ INSPECTION,Inspection
 instance base,Instance Base
 instance generation,Instance Generation
 instance segmentation,Instance Segmentation
-Instance Selection,Instance Selection
 INSTRUCTION,Instruction
 instruction,Instruction
 Instructional design,Instructional Design
 Instructional quality,Instructional Quality
 instructional technologies,Instructional Technologies
 Integrated Development Interface (IDE),Integrated Development Interface
-Integrated Online-Offline Character Recognition,Integrated Online-Offline Character Recognition
 Integrated optics,Integrated Optics
 Integrated recognition model,Integrated Recognition Model
 INTEGRATED SEGMENTATION,Integrated Segmentation
@@ -5296,13 +4423,10 @@ INTELLIGENCE,Intelligence
 intelligent CAD,Intelligent Cad
 Intelligent character recognition,Intelligent Character Recognition
 Intelligent Character Recognition (ICR),Intelligent Character Recognition
-Intelligent Designing System,Intelligent Designing System
 intelligent document processing,Intelligent Document Processing
 intelligent image processing,Intelligent Image Processing
 intelligent information systems,Intelligent Information Systems
-Intelligent Interface,Intelligent Interface
 Intelligent interfaces,Intelligent Interface
-Intelligent Multi-Expert System,Intelligent Multi-Expert System
 intelligent network,Intelligent Network
 intelligent recognition,Intelligent Recognition
 intelligent score,Intelligent Score
@@ -5314,7 +4438,6 @@ intelligent tutoring system,Intelligent Tutoring System
 Intelligent tutoring systems,Intelligent Tutoring Systems
 intelligent tutoring systems,Intelligent Tutoring Systems
 intelligent user interface,Intelligent User Interfaces
-Intelligent User Interfaces,Intelligent User Interfaces
 Intelligent word recognition,Intelligent Word Recognition
 INTENSIVE-CARE-UNIT,Intensive-Care-Unit
 Intent recognition,Intent Recognition
@@ -5333,7 +4456,6 @@ Interactive learning environments,Interactive Learning Environments
 interactive machine design,Interactive Machine Design
 interactive machine learning,Interactive Machine Learning
 Interactive machine translation,Interactive Machine Translation
-Interactive Pattern Recognition,Interactive Pattern Recognition
 Interactive pattern recognition,Interactive Pattern Recognition
 Interactive predictive processing,Interactive Predictive Processing
 Interactive recognition,Interactive Recognition
@@ -5341,7 +4463,6 @@ interactive recognition,Interactive Recognition
 interactive system,Interactive System
 interactive training,Interactive Training
 INTERACTIVE TRANSCRIPTION,Interactive Transcription
-Interactive Transcription,Interactive Transcription
 Interactive transcription,Interactive Transcription
 Interest points,Interest Points
 interesting field,Interesting Field
@@ -5353,33 +4474,25 @@ INTERLEXICAL HOMOGRAPHS,Interlexical Homographs
 INTERMEDIATE-GRADE WRITERS,Intermediate-Grade Writers
 INTERNAL-MODELS,Internal-Models
 INTERNET,Internet
-Internet Data Security,Internet Data Security
 Internet of things,Internet Of Things
 internet traffic prediction,Internet Traffic Prediction
-Interoperability,Interoperability
 interoperability,Interoperability
 interoperability problem,Interoperability Problem
-Interplanetary,Interplanetary
 INTERPOLATION,Interpolation
-Interpolation,Interpolation
 interpolation,Interpolation
 interpolation based feature,Interpolation Based Feature
 interpretability,Interpretability
 INTERPRETATION,Interpretation
 interpretation of two-dimensional structures,Interpretation Of Two-Dimensional Structures
-Interpreters,Interpreters
 intersections,Intersections
 interval type-2 fuzzy sets,Interval Type-2 Fuzzy Sets
 INTERVALS,Intervals
 interword distances,Interword Distances
 Intuitive interaction,Intuitive Interaction
-Invariance,Invariance
 invariance,Invariance
 INVARIANT,Invariant
-Invariant,Invariant
 invariant arrangements,Invariant Arrangements
 invariant feature,Invariant Feature
-Invariant Features,Invariant Features
 Invariant features,Invariant Features
 invariant features,Invariant Features
 INVARIANT IMAGE RECOGNITION,Invariant Image Recognition
@@ -5387,7 +4500,6 @@ Invariant moments,Invariant Moments
 invariant pattern extraction,Invariant Pattern Extraction
 Invariant pattern recognition,Invariant Pattern Recognition
 INVARIANT PATTERN-RECOGNITION,Invariant Pattern-Recognition
-Invariant Properties,Invariant Properties
 Invariant representation,Invariant Representation
 INVARIANTS,Invariants
 in-vehicle system,In-Vehicle System
@@ -5400,10 +4512,7 @@ INVOLVEMENT,Involvement
 in-water handwriting,In-Water Handwriting
 IR with noisy text,Ir With Noisy Text
 Iranian cities,Iranian Cities
-Iranshahr 3,Iranshahr 3
-Iris and MNIST experiments,Iris and MNIST experiments
 IRIS RECOGNITION,Iris Recognition
-Iron Age,Iron Age
 IRON-GALL INK,Iron-Gall Ink
 Irregular applications,Irregular Applications
 IRRELEVANT VARIABILITY NORMALIZATION,Irrelevant Variability Normalization
@@ -5414,7 +4523,6 @@ ISKN Repaper,Iskn Repaper
 Island-based projection,Island-Based Projection
 island-driven search,Island-Driven Search
 isolated Bangla character recognition,Isolated Bangla Character Recognition
-Isolated Character Recognition,Isolated Character Recognition
 isolated character recognition,Isolated Character Recognition
 isolated character recongition,Isolated Character Recongition
 isolated character/glyph recognition,Isolated Character/Glyph Recognition
@@ -5428,11 +4536,9 @@ isolated handwritten characters recognition,Isolated Handwritten Characters Reco
 lsolated handwritten digits,Isolated Handwritten Digits
 ISOLATED WORDS,Isolated Words
 isolated words,Isolated Words
-Isomap,Isomap
 ISOMORPHISM,Isomorphism
 Isothetic cover,Isothetic Cover
 ISSUES,Issues
-Itakura Parallelogram Band,Itakura Parallelogram Band
 item extraction,Item Extraction
 Iterated Function Systems (IFS),Iterated Function Systems
 iterative learning,Iterative Learning
@@ -5443,7 +4549,6 @@ Jaccard distance,Jaccard Distance
 JACOBI-FOURIER MOMENTS,Jacobi-Fourier Moments
 Janus MoSSe,Janus Mosse
 JAPANESE,Japanese
-Japanese,Japanese
 Japanese character recognition,Japanese Character Recognition
 JAPANESE CHARACTERS,Japanese Characters
 Japanese handwriting,Japanese Handwriting
@@ -5454,107 +4559,73 @@ JAPANESE TEXT RECOGNITION,Japanese Text Recognition
 JAPANESE ZIP CODE,Japanese Zip Code
 Japanese-character recognition,Japanese-Character Recognition
 JAVA,Java
-Java,Java
 Java framework,Java Framework
 JAVA Optimization,Java Optimization
-Javanesse Character Recognition,Javanesse Character Recognition
 Jawi character recognition,Jawi Character Recognition
 joint Bayesian,Joint Bayesian
 joint directional probability distributions,Joint Directional Probability Distributions
 joint movements,Joint Movements
-Joint Photographic Experts Group,Joint Photographic Experts Group
 joint training,Joint Training
-Journal,Journal
-JPEG,JPEG
-JPEG2000,JPEG2000
 JUMP DETECTION,Jump Detection
-Junclets,Junclets
 Junction detection,Junction Detection
 Junction point,Junction Point
 junction point,Junction Point
 Junction point elimination,Junction Point Elimination
 junctions,Junctions
-K- Graphemes,K- Graphemes
-K Nearest Neighbor Classifier,K Nearest Neighbor Classifier
 k nearest neighbor rule,K Nearest Neighbor Rule
 K nearest neighbors,K Nearest Neighbors
 k Nearest Neighbors,K Nearest Neighbors
-K-12,K-12
 Kaldi toolkit,Kaldi Toolkit
-Kalman Filter,Kalman Filter
 Kalman filter,Kalman Filter
 Kana-to-Kanji conversation,Kana-To-Kanji Conversation
 KANA-TO-KANJI CONVERSION,Kana-To-Kanji Conversion
 KANJI,Kanji
 KANJI CHARACTER RECOGNITION,Kanji Character Recognition
-Kanji Detection,Kanji Detection
-Kanji Recognition,Kanji Recognition
 Kanji recognition,Kanji Recognition
 KANNADA,Kannada
-Kannada,Kannada
 Kannada character recognition,Kannada Character Recognition
 Kannada character recogntion,Kannada Character Recogntion
 Kannada characters,Kannada Characters
 Kannada handwritten character recognition,Kannada Handwritten Character Recognition
-Kannada Script,Kannada Script
 Kannada script,Kannada Script
 k-ary classifiers,K-Ary Classifiers
 k-d trees,K-D Trees
 KERNEL,Kernel
-Kernel,Kernel
 kernel,Kernel
 kernels,Kernel
-Kernel Covariance Matrix,Kernel Covariance Matrix
 kernel density estimation,Kernel Density Estimation
 Kernel function,Kernel Function
 kernel function,Kernel Function
 Kernel learning,Kernel Learning
-Kernel Least Mean Square,Kernel Least Mean Square
 Kernel machine,Kernel Machine
 Kernel method,Kernel Method
 kernel method,Kernel Method
 Kernel methods,Kernel Method
-Kerning,Kerning
 ketanserin,Ketanserin
-KEVR,KEVR
 keyboard handwriting,Keyboard Handwriting
-Keyboarding,Keyboarding
 keyboarding,Keyboarding
 Keypad based entry,Keypad Based Entry
-Keypoints,Keypoints
 Keyword extraction,Keyword Extraction
 Keywords extraction,Keyword Extraction
 Keyword search,Keyword Search
 keyword search,Keyword Search
-Keyword Searching,Keyword Searching
-Keyword Spotting,Keyword Spotting
 Keyword spotting,Keyword Spotting
 keyword spotting,Keyword Spotting
 Keyword spotting for handwritten text,Keyword Spotting For Handwritten Text
-KHATT,KHATT
-KHATT database,KHATT database
 KHATT data-set,KHATT Dataset
 Khmer alphabet,Khmer Alphabet
-Khmer Palm Leaf Manuscript,Khmer Palm Leaf Manuscript
 KINDERGARTEN,Kindergarten
-Kindergarten,Kindergarten
-Kindergarteners,Kindergarteners
-Kinect Sensor,Kinect Sensor
 KINEMATIC ANALYSIS,Kinematic Analysis
 kinematic analysis,Kinematic Analysis
 Kinematic features,Kinematic Features
 KINEMATIC THEORY,Kinematic Theory
-Kinematic Theory,Kinematic Theory
 Kinematic theory,Kinematic Theory
 kinematic theory,Kinematic Theory
 kinematic theory of human movements,Kinematic Theory Of Human Movements
 Kinematic Theory of rapid human movements,Kinematic Theory Of Rapid Human Movements
 KINEMATICS,Kinematics
 kinematographic analysis,Kinematographic Analysis
-Kirsch Gradient Operator,Kirsch Gradient Operator
-KL distance,KL distance
 Kmeans,K-Means
-K-Means,K-Means
 k-means,K-Means
 K-means algorithm,K-Means Algorithm
 k-means algorithm,K-Means Algorithm
@@ -5584,54 +4655,37 @@ KNN and C-KNN classifier,Knn And C-Knn Classifier
 KNN Classification,Knn Classification
 k-NN classification,K-NN Classification
 KNN Fuzzy classification,K-NN Fuzzy Classification
-K-NN/SVM,K-NN/SVM
 KNOWLEDGE,Knowledge
-Knowledge Acquisition,Knowledge Acquisition
 knowledge acquisition,Knowledge Acquisition
 Knowledge base,Knowledge Base
 knowledge base,Knowledge Base
 Knowledge based approach,Knowledge Based Approach
 knowledge based neural networks,Knowledge Based Neural Networks
 knowledge based segmentation,Knowledge Based Segmentation
-Knowledge Distillation,Knowledge Distillation
 Knowledge extraction,Knowledge Extraction
 knowledge extraction,Knowledge Extraction
 Knowledge fusion,Knowledge Fusion
 knowledge management,Knowledge Management
 KNOWLEDGE MODELING,Knowledge Modeling
 knowledge processing,Knowledge Processing
-Knowledge Reuse,Knowledge Reuse
 knowledge sharing,Knowledge Sharing
-Knowledge Transfer,Knowledge Transfer
 knowledge transfer,Knowledge Transfer
 knowledge-based generation,Knowledge-Based Generation
 Kohonen Network,Kohonen Neural Network
 Kohonen network (SOM),Kohonen Neural Network
-Kohonen Neural Network,Kohonen Neural Network
 Kohonen neural network,Kohonen Neural Network
-Kohonen Self-Organizing Map,Kohonen Self-Organizing Map
 Kohonen's self-organizing feature map,Kohonen Self-Organizing Map
 Kolmogorov complexity,Kolmogorov Complexity
-Kolmogorovu,Kolmogorovu
-Korean,Korean
 Korean character recognition,Korean Character Recognition
 KOREAN CHARACTERS,Korean Characters
 Korean Handwriting recognition,Korean Handwriting Recognition
-Korean OCR,Korean OCR
-KPTI,KPTI
-Krawtchouk,Krawtchouk
 KRILL HERD,Krill Herd
 Krill-herd optimization,Krill-Herd Optimization
-KSVCR,KSVCR
 KSVD dictionary,KSVD Dictionary
-Kufic,Kufic
-Kullback-Leibler Divergence,Kullback-Leibler Divergence
 Kullback-Leibler divergence,Kullback-Leibler Divergence
-Kurrentschrift,Kurrentschrift
 "l(2,1)","L(2,1)"
 "l(p,1)-norm","L(P,1)-Norm"
 L-0-gradient minimisation algorithm,L-0-Gradient Minimisation Algorithm
-L2 Chinese,L2 Chinese
 L2 regularization,L2 Regularization
 L2 regularization factor,L2 Regularization Factor
 label coding,Label Coding
@@ -5646,10 +4700,8 @@ lacunarity,Lacunarity
 Lagrange's interpolation,Lagrange's Interpolation
 Lampung characters,Lampung Characters
 LANGUAGE,Language
-Language,Language
 Language and literacy,Language And Literacy
 language bursts,Language Bursts
-Language Detection,Language Detection
 Language engineering,Language Engineering
 LANGUAGE IDENTIFICATION,Language Identification
 Language identification,Language Identification
@@ -5667,7 +4719,6 @@ Language Model,Language Models
 Language model,Language Models
 language model,Language Models
 LANGUAGE MODELS,Language Models
-Language Models,Language Models
 Language models,Language Models
 language models,Language Models
 Language models (LMs),Language Models
@@ -5675,12 +4726,10 @@ language training,Language Training
 language-independency constraint,Language-Independency Constraint
 language-model postprocessing,Language-Model Postprocessing
 LANGUAGES,Languages
-Languages,Languages
 languages,Languages
 Lanna historical documents,Lanna Historical Documents
 Lao character recognition,Lao Character Recognition
 LAPLACIAN EIGENMAPS,Laplacian Eigenmaps
-LAR,LAR
 Large arabic word vocabulary,Large Arabic Word Vocabulary
 Large category,Large Category
 LARGE CHARACTER SET,Large Character Set
@@ -5688,7 +4737,6 @@ large character set,Large Character Set
 large data,Large Data
 Large data set,Large Datasets
 Large datasets,Large Datasets
-Large Eigen Values,Large Eigen Values
 Large margin semi-supervised learning,Large Margin Semi-Supervised Learning
 large number of classes,Large Number Of Classes
 Large OCR system,Large OCR System
@@ -5698,7 +4746,6 @@ Large vocabulary Handwriting Recognition,Large Vocabulary Handwriting Recognitio
 large-scale categories,Large-Scale Categories
 large scale classification problems,Large-Scale Classification Problems
 large-scale pattern recognition,Large-Scale Pattern Recognition
-Large-Scale Probabilistic Indexing,Large-Scale Probabilistic Indexing
 large-scale synthesis,Large-Scale Synthesis
 large-set classification,Large-Set Classification
 LARGE-SET HANDWRITTEN CHARACTER RECOGNITION,Large-Set Handwritten Character Recognition
@@ -5713,8 +4760,6 @@ Latent space,Latent Space
 latent structure modeling,Latent Structure Modeling
 Latent-dynamic conditional random fields,Latent-Dynamic Conditional Random Fields
 Latent-level adversarial learning,Latent-Level Adversarial Learning
-LaTeX,LaTeX
-Latin,Latin
 Latin and Arabic handwriting recognition,Latin And Arabic Handwriting Recognition
 Latin characters,Latin Characters
 Latin handwriting recognition,Latin Handwriting Recognition
@@ -5724,7 +4769,6 @@ Latin mediaeval handwritings,Latin Mediaeval Handwritings
 Latin script,Latin Script
 Latin script classification,Latin Script Classification
 lattice,Lattice
-Lattice Combination,Lattice Combination
 lattice pruning,Lattice Pruning
 lattice refinement,Lattice Refinement
 L-attributed grammar,L-Attributed Grammar
@@ -5732,16 +4776,10 @@ Laws' texture energy measures,Laws' Texture Energy Measures
 Layered outline extraction,Layered Outline Extraction
 Layered search tree,Layered Search Tree
 LAYOUT,Layout
-Layout,Layout
 LAYOUT ANALYSIS,Layout Analysis
-Layout Analysis,Layout Analysis
 Layout analysis,Layout Analysis
 layout analysis,Layout Analysis
 layout segmentation,Layout Segmentation
-LBP,LBP
-LCS,LCS
-LDA,LDA
-LDP,LDP
 Leaf swing energy,Leaf Swing Energy
 leaky-integrate-fire (LIF) neuron,Leaky-Integrate-Fire Neuron
 Leap motion,Leap Motion
@@ -5749,15 +4787,12 @@ Leap motion controller,Leap Motion Controller
 Leap motion sensor,Leap Motion Sensor
 Learned edit distance,Learned Edit Distance
 LEARNING,Learning
-Learning,Learning
 learning,Learning
 learning (artificial intelligence),Learning (Artificial Intelligence)
 LEARNING ALGORITHM,Learning Algorithm
 learning algorithm,Learning Algorithm
 LEARNING ALGORITHMS,Learning Algorithm
 learning and knowledge discovery,Learning And Knowledge Discovery
-Learning Assessment,Learning Assessment
-Learning Attitudes,Learning Attitudes
 learning best model granularity,Learning Best Model Granularity
 LEARNING CAPABILITIES,Learning Capabilities
 learning classifier systems,Learning Classifier Systems
@@ -5770,7 +4805,6 @@ Learning mathematics,Learning Mathematics
 learning methods,Learning Methods
 learning optimal feature extraction interval,Learning Optimal Feature Extraction Interval
 learning optimal hidden layer,Learning Optimal Hidden Layer
-Learning Optimization,Learning Optimization
 LEARNING PROTOTYPES,Learning Prototypes
 learning rate,Learning Rate
 learning rate annealing algorithm,Learning Rate Annealing Algorithm
@@ -5779,7 +4813,6 @@ learning speedup,Learning Speedup
 Learning systems,Learning Systems
 Learning the graph edit costs,Learning The Graph Edit Costs
 LEARNING VECTOR QUANTIZATION,Learning Vector Quantization
-Learning Vector Quantization,Learning Vector Quantization
 learning vector quantization,Learning Vector Quantization
 Learning Vector Quantization (LVQ),Learning Vector Quantization
 Learning Vector Quantization LVQ,Learning Vector Quantization
@@ -5790,7 +4823,6 @@ LEARNING-DISABLED STUDENTS,Learning-Disabled Students
 Learning-free,Learning-Free
 learning-free,Learning-Free
 least general automata,Least General Automata
-Least Mean Square,Least Mean Square
 LECTURE,Lecture
 Lecture video,Lecture Video
 lecture videos,Lecture Videos
@@ -5799,7 +4831,6 @@ left-to-right hidden Markov models,Left-To-Right Hidden Markov Models
 legal agreements,Legal Agreements
 LEGAL AMOUNT,Legal Amount
 legal amount interpretation,Legal Amount Interpretation
-Legal Amount Recognition,Legal Amount Recognition
 Legal amount recognition,Legal Amount Recognition
 legal amount recognition,Legal Amount Recognition
 LEGAL AMOUNTS,Legal Amounts
@@ -5807,7 +4838,6 @@ Legal identity for all,Legal Identity For All
 Legendre polynomials approximations,Legendre Polynomials Approximations
 Legendre-Sobolev series,Legendre-Sobolev Series
 LEGIBILITY,Legibility
-Legibility,Legibility
 legibility estimation,Legibility Estimation
 Legibility evaluation,Legibility Evaluation
 LeNet,Lenet
@@ -5817,7 +4847,6 @@ Letter frequency,Letter Frequency
 LETTER PERCEPTION,Letter Perception
 letter perception,Letter Perception
 LETTER RECOGNITION,Letter Recognition
-Letter Recognition,Letter Recognition
 Letter recognition,Letter Recognition
 letter recognition,Letter Recognition
 letter spotting,Letter Spotting
@@ -5832,7 +4861,6 @@ levenshtein distance,Levenshtein Distance
 lexemes,Lexemes
 LEXICAL DATABASE,Lexical Database
 LEXICAL INFORMATION,Lexical Information
-Lexicographic Toloka (Crowdsourcing),Lexicographic Toloka (Crowdsourcing)
 LEXICON,Lexicon
 lexicon,Lexicon
 lexicon based decoding,Lexicon Based Decoding
@@ -5855,19 +4883,14 @@ lexicon-free text,Lexicon-Free Text
 LIBLINEAR,Liblinear
 LibLIN-EAR,Liblin-Ear
 LIBRARY,Library
-Library,Library
 library,Library
-LIBSVM,LIBSVM
-LibSVM,LibSVM
 License plate character recognition,License Plate Character Recognition
 License plate recognition,License Plate Recognition
-Licenses,Licenses
 ligature model,Ligature Model
 LIGATURE MODELING,Ligature Modeling
 LIGATURE,Ligatures
 Ligature,Ligatures
 ligature,Ligatures
-Ligatures,Ligatures
 ligatures,Ligatures
 Light ray,Light Ray
 Likelihood analysis,Likelihood Analysis
@@ -5878,9 +4901,7 @@ line adjacency graph,Line Adjacency Graph
 LINE APPROXIMATION,Line Approximation
 LINE DENSITY,Line Density
 line density direction feature,Line Density Direction Feature
-Line Density Equalization,Line Density Equalization
 LINE DETECTION,Line Detection
-Line Detection,Line Detection
 line detection,Line Detection
 LINE EXTRACTION,Line Extraction
 Line extraction,Line Extraction
@@ -5895,7 +4916,6 @@ line quality,Line Quality
 Line removal,Line Removal
 line removal,Line Removal
 LINE SEGMENTATION,Line Segmentation
-Line Segmentation,Line Segmentation
 Line segmentation,Line Segmentation
 line segmentation,Line Segmentation
 line segments recognition with unevenness,Line Segments Recognition With Unevenness
@@ -5903,7 +4923,6 @@ LINE SIGNATURE VERIFICATION,Line Signature Verification
 Linear assignment problem,Linear Assignment Problem
 Linear classifier,Linear Classifier
 LINEAR CORRELATION CLASSIFIERS,Linear Correlation Classifiers
-Linear Discriminant Analysis,Linear Discriminant Analysis
 Linear discriminant analysis,Linear Discriminant Analysis
 Linear Discriminant Analysis (LDA),Linear Discriminant Analysis
 LINEAR DISCRIMINANT-ANALYSIS,Linear Discriminant Analysis
@@ -5914,7 +4933,6 @@ Linear model,Linear Model
 linear models,Linear Model
 Linear principal transformation,Linear Principal Transformation
 linear regression-based features,Linear Regression-Based Features
-Linear SVM,Linear SVM
 linear SVM-based classification,Linear SVM-Based Classification
 linear transform,Linear Transform
 LINEAR TREE CLASSIFIERS,Linear Tree Classifiers
@@ -5931,7 +4949,6 @@ linguistic fuzzy classification,Linguistic Fuzzy Classification
 LINGUISTIC HEDGES,Linguistic Hedges
 linguistic modeling,Linguistic Modeling
 LINGUISTIC PROCESSING,Linguistic Processing
-Linguistic Variable,Linguistic Variable
 linguistics,Linguistics
 link weight,Link Weight
 Linked data,Linked Data
@@ -5940,23 +4957,15 @@ lipreading,Lip-Reading
 lip-reading,Lip-Reading
 LISTENING COMPREHENSION,Listening Comprehension
 LITERACY,Literacy
-Literacy,Literacy
 literacy,Literacy
 literal amount recognition,Literal Amount Recognition
 LITERAL AMOUNTS,Literal Amounts
 literal amounts,Literal Amounts
-LK tracking,LK tracking
-LLAH,LLAH
-LLVM Intermediate Representation,LLVM Intermediate Representation
 LLVM intermediate representation,LLVM Intermediate Representation
-LM-BP,LM-BP
-LMCA,LMCA
 LMCA_Database,Lmca Database
-LMS,LMS
 LOCAL AFFINE TRANSFORMATION,Local Affine Transformation
 local and global view,Local And Global View
 local binary fitting energy,Local Binary Fitting Energy
-Local Binary Pattern,Local Binary Pattern
 local binary pattern,Local Binary Pattern
 Local Binary Pattern (LBP),Local Binary Pattern
 Local Binary Pattern(LBP),Local Binary Pattern
@@ -5964,14 +4973,10 @@ LOCAL BINARY PATTERNS,Local Binary Pattern
 local connections,Local Connections
 local connectivity directions map (LCDM),Local Connectivity Directions Map
 local contour features,Local Contour Features
-Local Derivative Patterns,Local Derivative Patterns
 Local descriptors,Local Descriptors
 local difference value,Local Difference Value
-Local Directional Pattern,Local Directional Pattern
 Local directional pattern,Local Directional Pattern
 local feature,Local Feature
-Local Feature Analysis,Local Feature Analysis
-Local Features,Local Features
 local features,Local Features
 Local gradient feature descriptor,Local Gradient Feature Descriptor
 local image features,Local Image Features
@@ -5980,14 +4985,8 @@ local information,Local Information
 local learning framework,Local Learning Framework
 local ly-adaptive thresholding,Local Ly-Adaptive Thresholding
 local orientations,Local Orientations
-Local Otsu,Local Otsu
 Local otsu,Local Otsu
-Local PCA,Local PCA
-Local Phase Quantization,Local Phase Quantization
 local receptive fields,Local Receptive Fields
-Local Sensitivity Hashing,Local Sensitivity Hashing
-Local Slant,Local Slant
-Local Stability,Local Stability
 Local Standard deviation,Local Standard Deviation
 Local standard deviation,Local Standard Deviation
 Local structural pattern,Local Structural Pattern
@@ -6017,13 +5016,11 @@ lognormal function,Lognormal Function
 lognormal models,Lognormal Models
 lognormality,Lognormality
 Lognormality principle,Lognormality Principle
-Lognormals,Lognormals
 Logo detection,Logo Detection
 logos,Logos
 log-space distribution,Log-Space Distribution
 log-structured storage,Log-Structured Storage
 long distance restriction,Long Distance Restriction
-Long Short Term Memory,Long Short Term Memory
 Long short term memory,Long Short Term Memory
 long short term memory,Long Short Term Memory
 Long Short -Term Memory,Long Short Term Memory
@@ -6041,22 +5038,18 @@ LSTM,Long Short Term Memory
 lstm,Long Short Term Memory
 Long Short Term Memory (LSTM) autoencoders,Long Short Term Memory  Autoencoders
 Long short term memory (LSTM) networks,Long Short Term Memory Network
-Long Short Term Memory Network,Long Short Term Memory Network
 Long short term memory network,Long Short Term Memory Network
 long short term memory network,Long Short Term Memory Network
 Long short-term memory network,Long Short Term Memory Network
 Long-short term memory networks,Long Short Term Memory Network
 LSTM network,Long Short Term Memory Network
 longest run,Longest Run
-Longest Run Features,Longest Run Features
 Longitudinal study,Longitudinal Study
 look-ahead technique,Look-Ahead Technique
 Loop and Gaussian Grid Feature,Loop And Gaussian Grid Feature
 loops,Loops
 loopy belief propagation,Loopy Belief Propagation
 Low dimensional features,Low Dimensional Features
-Low Latency Interface,Low Latency Interface
-Low Level Stroke,Low Level Stroke
 low power,Low Power
 low power design,Low Power Design
 low resolution,Low Resolution
@@ -6070,23 +5063,15 @@ low-rank approximation,Low-Rank Approximation
 Low-rank recovery,Low-Rank Recovery
 low-rank recovery,Low-Rank Recovery
 low-resource data,Low-Resource Data
-LPQ,LPQ
-LRF,LRF
-LS-SVM,LS-SVM
 LSTM acceleration and compression,LSTM Acceleration And Compression
 LSTM-CRF,LSTM CRF
-LSTM RNN,LSTM RNN
 LSTM-RNN,LSTM RNN
-LTS rules,LTS rules
-Lucene,Lucene
 Lukasiewicz implication,Lukasiewicz Implication
-LVQ,LVQ
 Lyapunov methods,Lyapunov Methods
 lyrics recognition,Lyrics Recognition
 MAC,Mac
 MACHINE,Machine
 MACHINE LEARNING,Machine Learning
-Machine Learning,Machine Learning
 Machine learning,Machine Learning
 machine learning,Machine Learning
 Machine learning algorithms,Machine Learning Algorithms
@@ -6095,14 +5080,12 @@ Machine learning classifiers,Machine Learning Classifiers
 Machine Learning Model (ML Model),Machine Learning Model
 Machine learning techniques,Machine Learning Techniques
 machine print,Machine Print
-Machine Print Recognition,Machine Print Recognition
 machine reading,Machine Reading
 MACHINE RECOGNITION,Machine Recognition
 Machine recognition,Machine Recognition
 Machine translation,Machine Translation
 machine translation,Machine Translation
 machine translation of OCR text,Machine Translation Of OCR Text
-Machine Vision,Machine Vision
 Machine Printed,Machine-Printed
 Machine printed,Machine-Printed
 Machine-printed and Hand-written text separation,Machine-Printed And Hand-Written Text Separation
@@ -6112,15 +5095,10 @@ Machine printed text,Machine-Printed Text
 machine printed text,Machine-Printed Text
 MACHINE-PRINTED TEXT,Machine-Printed Text
 machine-printed text recognition,Machine-Printed Text Recognition
-Machinery,Machinery
 MACHINES,Machines
 machine-typed documents,Machine-Typed Documents
 macrostructure analysis,Macrostructure Analysis
-MADCAT dataset,MADCAT dataset
-Magazine,Magazine
-MAG-mu IMU,MAG-mu IMU
 MAGNETIC CLOUDS,Magnetic Clouds
-magnetic domain wall (DW),magnetic domain wall (DW)
 Magnetic field fluctuations,Magnetic Field Fluctuations
 Magnetic fields,Magnetic Fields
 magnetic resonance imaging,Magnetic Resonance Imaging
@@ -6132,11 +5110,8 @@ Mahalanobis metric,Mahalanobis Distance Metric
 Mailing address recognition,Mailing Address Recognition
 Major stroke,Major Stroke
 majority vote,Majority Vote
-Malayalam,Malayalam
-Malayalam Character Recognition,Malayalam Character Recognition
 Malayalam character recognition,Malayalam Character Recognition
 Malayalam handwriting recognition,Malayalam Handwriting Recognition
-Malayalam Handwritten Character Recognition,Malayalam Handwritten Character Recognition
 Malayalam handwritten characters,Malayalam Handwritten Characters
 Malayalam handwritten OCR,Malayalam Handwritten OCR
 Malayalam language,Malayalam Language
@@ -6145,11 +5120,8 @@ MANAGEMENT,Management
 Manifold learning,Manifold Learning
 manifold learning,Manifold Learning
 Manifold structure,Manifold Structure
-Manipuri,Manipuri
 man-machine interaction,Man-Machine Interaction
-Manual Handwriting Texts Recognition,Manual Handwriting Texts Recognition
 MANUSCRIPT,Manuscript
-Manuscript,Manuscript
 manuscript,Manuscript
 Manuscript (unjoined) letters,Manuscript (Unjoined) Letters
 manuscript analysis,Manuscript Analysis
@@ -6157,7 +5129,6 @@ MANUSCRIPT COLLECTIONS,Manuscript Collections
 manuscript exploration,Manuscript Exploration
 manuscript investigation,Manuscript Investigation
 MANUSCRIPTS,Manuscripts
-Manuscripts,Manuscripts
 manuscripts,Manuscripts
 manuscripts annotation,Manuscripts Annotation
 MAP-adaptation,Map Adaptation
@@ -6167,9 +5138,7 @@ MapReduce,Mapreduce
 Map,Maps
 map,Maps
 MAPS,Maps
-Marathi Character,Marathi Character
 MARBLE TEXTURES,Marble Textures
-Margin,Margin
 Marginalized kernel,Marginalized Kernel
 margin-based training,Margin-Based Training
 Markov Chain,Markov Chains
@@ -6177,34 +5146,27 @@ MARKOV CHAINS,Markov Chains
 Markov chains,Markov Chains
 MARKOV MESH,Markov Mesh
 MARKOV MODEL,Markov Model
-Markov Model,Markov Model
 Markov models,Markov Model
 MARKOV-MODELS,Markov Model
 Markov processes,Markov Processes
 Markov random field,Markov Random Fields
-Markov Random Fields,Markov Random Fields
 Markov Random fields,Markov Random Fields
 Markov random fields,Markov Random Fields
 Markovian models,Markovian Models
-Marriage Licenses,Marriage Licenses
 Marriage register books,Marriage Register Books
 marriage register books,Marriage Register Books
-MARY (Modular Architecture for Research on Speech Synthesis),MARY (Modular Architecture for Research on Speech Synthesis)
 maskmatching approach,Mask-Matching Approach
 mask-matching approach,Mask-Matching Approach
-Mass,Mass
 Mass distribution,Mass Distribution
 Mass functions,Mass Functions
 massive data parallelism,Massive Data Parallelism
 MASSIVELY-PARALLEL PROCESSING,Massively-Parallel Processing
-Matching,Matching
 matching,Matching
 matching curve,Matching Curve
 Matching degree,Matching Degree
 matching degree,Matching Degree
 Matching patterns,Matching Patterns
 Materials and methods,Materials And Methods
-Math Recognition,Math Recognition
 Math recognition,Math Recognition
 mathematic expression,Mathematic Expression
 mathematical character recognition,Mathematical Character Recognition
@@ -6231,12 +5193,10 @@ Mathematical morphology,Mathematical Morphology
 mathematical morphology,Mathematical Morphology
 mathematical notation recognition,Mathematical Notation Recognition
 Mathematical symbol classification and rejection,Mathematical Symbol Classification And Rejection
-Mathematics,Mathematics
 Mathematics education,Mathematics Education
 mathematical recognition,Mathematics Recognition
 mathematics recognition,Mathematics Recognition
 MATLAB,Matlab
-Matlab,Matlab
 MATRIX,Matrix
 matrix,Matrix
 matrix algebra,Matrix Algebra
@@ -6249,7 +5209,6 @@ maximum entropy,Maximum Entropy
 maximum likelihood,Maximum Likelihood
 maximum likelihood approach,Maximum Likelihood Approach
 maximum likelihood estimation,Maximum Likelihood Estimation
-Maximum Margin Learning,Maximum Margin Learning
 maximum marginal a posteriori probability,Maximum Marginal A Posteriori Probability
 maximum mean discrepancy,Maximum Mean Discrepancy
 Maximum mutual information,Maximum Mutual Information
@@ -6258,21 +5217,12 @@ MAXIMUM SIMILAR-MORPHISM,Maximum Similar-Morphism
 MAXIMUM-LIKELIHOOD,Maximum-Likelihood
 max-margin,Max-Margin
 Max-margin Markov random field,Max-Margin Markov Random Field
-Maxout,Maxout
 max-pool,Max-Pool
 Max-pooling,Max-Pooling
 max-product belief propagation,Max-Product Belief Propagation
 Maya glyph,Maya Glyph
 MAYASTROUN-database,Mayastroun-Database
 Mayek27&#8221,Mayek27
-MCE,MCE
-MCS,MCS
-MDA,MDA
-MDLSTM,MDLSTM
-MD-LSTM,MD-LSTM
-MDLSTM technologies,MDLSTM technologies
-MDRNN,MDRNN
-MDSLTM,MDSLTM
 mean field,Mean Field
 MEAN-FIELD,Mean Field
 measure,Measure
@@ -6282,17 +5232,14 @@ Mediaeval handwritings,Mediaeval Handwritings
 medial representation,Medial Representation
 Median blur filtering,Median Blur Filtering
 Median computation,Median Computation
-Median Filter,Median Filter
 Median filter,Median Filter
 median filtering,Median Filtering
-Medical Data,Medical Data
 Medical diagnosis,Medical Diagnosis
 medical diagnosis,Medical Diagnosis
 Medical image retrieval,Medical Image Retrieval
 medical imaging,Medical Imaging
 MEDICAL INFORMATION BUS (MIB),Medical Information Bus
 medical information systems,Medical Information Systems
-Medical Symbols,Medical Symbols
 "medical-records systems, computerised","Medical-Records Systems, Computerised"
 MEDICATION ERRORS,Medication Errors
 Medication errors,Medication Errors
@@ -6303,12 +5250,9 @@ MEDIEVAL HANDWRITINGS,Medieval Handwritings
 medieval manuscript,Medieval Manuscripts
 Medieval manuscripts,Medieval Manuscripts
 medieval manuscripts,Medieval Manuscripts
-Medieval Paleographic Scale,Medieval Paleographic Scale
 Medieval western manuscripts,Medieval Western Manuscripts
-Medium Filter,Medium Filter
 medium-sized vocabularies,Medium-Sized Vocabularies
 Meeting support systems,Meeting Support Systems
-Meitei Mayek,Meitei Mayek
 Meitei-Mayek,Meitei Mayek
 Membership function,Membership Function
 membership function,Membership Function
@@ -6322,45 +5266,33 @@ memory,Memory
 memory computing,Memory Computing
 MEMORY DISKS,Memory Disks
 memory hierarchy,Memory Hierarchy
-Memristive Crossbar,Memristive Crossbar
 memristive crossbar,Memristive Crossbar
 memristors,Memristors
-MEMS,MEMS
-Mensural Notation,Mensural Notation
 Mensural notation,Mensural Notation
 Mental number line,Mental Number Line
 Mental rotation,Mental Rotation
 MENTAL STRESS,Mental Stress
 Mental workload,Mental Workload
 MENU,Menu
-Mercer,Mercer
 merging,Merging
 MERGING OF FUZZY SEQUENTIAL MACHINES,Merging Of Fuzzy Sequential Machines
 M-estimation,M-Estimation
 METAANALYSIS,Meta-analysis
-Metaclasses,Metaclasses
 metaclasses,Metaclasses
 metadata,Metadata
 Meta-features Space,Meta-Features Space
-Meta-Heuristic Algorithms,Meta-Heuristic Algorithms
 metaheuristics optimization,Metaheuristics Optimization
 Meta-model evolution,Meta-Model Evolution
 metasynthesis,Metasynthesis
 Method of Outline Models,Method Of Outline Models
-Methodologies,Methodologies
 methodologies for practical application of neural networks,Methodologies For Practical Application Of Neural Networks
 METHODOLOGY,Methodology
-Methodology,Methodology
 Methodology for Speech Elicitation,Methodology For Speech Elicitation
 Methods of Handwritten Character Classification,Methods Of Handwritten Character Classification
 Metric learning,Metric Learning
 metric learning,Metric Learning
 metric space,Metric Spaces
 metric spaces,Metric Spaces
-MFCC,MFCC
-MGGI,MGGI
-MIC,MIC
-Microarray,Microarray
 microbencharking,Microbencharking
 microfilm processing,Microfilm Processing
 MICROGRAPHIA,Micrographia
@@ -6368,12 +5300,8 @@ micrographia,Micrographia
 microprocessor chips,Microprocessor Chips
 the microstructure level,Microstructure Level
 Mid-air interactions,Mid-Air Interactions
-Middle High German,Middle High German
-Midpoint,Midpoint
 MILD COGNITIVE IMPAIRMENT,Mild Cognitive Impairment
-Mild Cognitive Impairment,Mild Cognitive Impairment
 millimeter wave (mmWave),Millimeter Wave
-MIMO radar,MIMO radar
 min graph cut,Min Graph Cut
 mind map recognition,Mind Map Recognition
 mindmap recognition,Mindmap Recognition
@@ -6405,14 +5333,12 @@ minimum-distance classification (MDC) technique,Minimum-Distance Classification 
 Minimum-risk training,Minimum-Risk Training
 mining frequent patterns,Mining Frequent Patterns
 Minor stroke,Minor Stroke
-Minority Handwritten Digit,Minority Handwritten Digit
 mirror neurons,Mirror Neurons
 Mirror writing,Mirror Writing
 missing values,Missing Values
 MISSPELLING ERRORS CORRECTION,Misspelling Errors Correction
 mixed discriminant criteria,Mixed Discriminant Criteria
 mixed methods,Mixed Methods
-Mixed Programming,Mixed Programming
 Mixed script,Mixed Script
 Mixed-script document,Mixed-Script Document
 MIXTURE,Mixture
@@ -6425,62 +5351,42 @@ MIXTURE OUTPUT DISTRIBUTIONS,Mixture Output Distributions
 MIXTURES,Mixtures
 Mizo handwritten image to text,Mizo Handwritten Image To Text
 Mizo handwritten OCR,Mizo Handwritten OCR
-MLC-CRNN,MLC-CRNN
-ML-LPQ,ML-LPQ
-MLP,MLP
 MLP nelvvork,MLP Neural Network
 MLP neural Network,MLP Neural Network
 MLPNNs,MLP Neural Network
-MMI,MMI
-MMPI personality test,MMPI personality test
-MNIST,MNIST
-MNIST database,MNIST database
-MNIST Dataset,MNIST Dataset
 MNIST dataset,MNIST Dataset
-MNIST digits,MNIST digits
 mobile,Mobile
 Mobile agent,Mobile Agent
 mobile app,Mobile App
-Mobile Application,Mobile Application
 mobile application,Mobile Application
 mobile applications,Mobile Application
-Mobile Cloud Computing,Mobile Cloud Computing
-Mobile Computer,Mobile Computer
 Mobile computer,Mobile Computer
 Mobile computing,Mobile Computing
 mobile computing,Mobile Computing
 mobile conditions,Mobile Conditions
 Mobile device authentication,Mobile Device Authentication
-Mobile Devices,Mobile Devices
 Mobile devices,Mobile Devices
 mobile devices,Mobile Devices
 mobile grading,Mobile Grading
 Mobile handsets,Mobile Handsets
-Mobile Learning,Mobile Learning
 mobile learning,Mobile Learning
 mobile multimedia,Mobile Multimedia
 mobile OCR,Mobile OCR
 mobile phones,Mobile Phones
-Mobile Platform Evaluation,Mobile Platform Evaluation
 mobile text-entry,Mobile Text-Entry
 mobile-cameras,Mobile-Cameras
 MOCA,Moca
 Modality invariance,Modality Invariance
 MODE DETECTION,Mode Detection
-Mode Detection,Mode Detection
 MODEL,Model
 Model adaptation,Model Adaptation
 Model compression,Model Compression
 Model construction,Model Construction
-Model Development,Model Development
 model discriminant HMM (MD-HMM),Model Discriminant HMM
 model discrimination,Model Discrimination
 Model driven development,Model Driven Development
 model learning,Model Learning
-Model Management,Model Management
 Model migration,Model Migration
-Model Quality Index,Model Quality Index
-Model Retraining,Model Retraining
 Model selection,Model Selection
 model selection,Model Selection
 Model set reduction,Model Set Reduction
@@ -6489,62 +5395,40 @@ model-based clustering,Model-Based Clustering
 model-based normalization scheme,Model-Based Normalization Scheme
 model-based recognition,Model-Based Recognition
 Model-driven,Model-Driven
-Model-Driven Development,Model-Driven Development
 Model-driven Development,Model-Driven Development
-Modeling,Modeling
 modeling of computer architecture,Modeling Of Computer Architecture
 modeling robot arm,Modeling Robot Arm
 MODELS,Models
-Models,Models
-Modernized Transcripts,Modernized Transcripts
 MODES,Modes
-MODI lipi,MODI lipi
 MODI Script,Modi Script
 MODI script OCR,Modi Script OCR
 Modified center distance feature,Modified Center Distance Feature
 MODIFIED DIRECTION FEATURE,Modified Direction Feature
-Modified Direction Feature,Modified Direction Feature
 Modified direction feature,Modified Direction Feature
 modified direction feature,Modified Direction Feature
 modified direction frature,Modified Direction Frature
 modified directional feature,Modified Directional Feature
 modified earley's parsing algorithm,Modified Earley's Parsing Algorithm
-Modified Hausdorff Distance,Modified Hausdorff Distance
 Modified log-Gabor filter,Modified Log-Gabor Filter
 Modified log-Gabor filter transform,Modified Log-Gabor Filter Transform
 modified parsing algorithm,Modified Parsing Algorithm
 modified quadratic discriminant function,Modified Quadratic Discriminant Function
-Modified Self-Organizing Map,Modified Self-Organizing Map
 modified self-organizing map,Modified Self-Organizing Map
 modified viterbi algorithm,Modified Viterbi Algorithm
-Modified Water Reservoir,Modified Water Reservoir
-Modified Word Segmentation,Modified Word Segmentation
 Modified-Euler method,Modified-Euler Method
-Modular Granular Recognition Architecture,Modular Granular Recognition Architecture
 modular neural network,Modular Neural Networks
-Modular Neural Networks,Modular Neural Networks
 modular neural networks,Modular Neural Networks
 MODULAR NEURAL-NETWORK,Modular Neural Networks
 modularity,Modularity
 MODULATION,Modulation
-Mokkan,Mokkan
 MOMENT INVARIANTS,Moment Invariants
 moment invariants,Moment Invariants
 MOMENTS,Moments
-Moments,Moments
-Mongolia Words,Mongolia Words
 Mongolia words,Mongolia Words
 mongolia words recognition,Mongolia Words Recognition
-Mongolian,Mongolian
 MONITORING,Monitoring
-Monograms,Monograms
-Monolingual,Monolingual
 Monte Carlo simulation,Monte Carlo Simulation
-MOOCs,MOOCs
-Mood,Mood
-Morhpological Enhancement,Morhpological Enhancement
 morphing,Morphing
-Morphological Analysis,Morphological Analysis
 MORPHOLOGICAL AWARENESS,Morphological Awareness
 morphological neural networks,Morphological Neural Networks
 morphological operation,Morphological Operations
@@ -6552,7 +5436,6 @@ Morphological operations,Morphological Operations
 morphological operators,Morphological Operators
 morphological systems,Morphological Systems
 MORPHOLOGY,Morphology
-Morphology,Morphology
 morphology,Morphology
 MORTALITY,Mortality
 mortality,Mortality
@@ -6593,39 +5476,19 @@ movement modeling,Movement Modeling
 MOVEMENTS,Movements
 MOVING SOUND SOURCES,Moving Sound Sources
 moving window-based space penetration algorithm,Moving Window-Based Space Penetration Algorithm
-MP generalized inverse,MP generalized inverse
-MPCA,MPCA
-MPE training,MPE training
-MPEG-7,MPEG-7
-MPFC,MPFC
-MQDF,MQDF
-MQDF retraining,MQDF retraining
-MQDF-CAN bybrid model,MQDF-CAN bybrid model
-MRF,MRF
-MRL-filters,MRL-filters
-MSE,MSE
-MSI,MSI
-MsLBP,MsLBP
-MST-based parsing,MST-based parsing
-Mufflelass SVM,Mufflelass SVM
-Multi Expert,Multi Expert
 Multi gradient,Multi Gradient
 multi keystroke,Multi Keystroke
-Multi Layer Perceptron,Multi Layer Perceptron
 Multi layer perceptron,Multi Layer Perceptron
 Multi layer perceptrons,Multi Layer Perceptrons
 Multi scale retinex,Multi Scale Retinex
 Multi task joint training,Multi Task Joint Training
 multi touch screen,Multi Touch Screen
-Multi-Agent Systems,Multi-Agent Systems
-Multi-Attention,Multi-Attention
 multi-branch,Multi-Branch
 MULTICLASS,Multiclass
 multiclass classification,Multiclass Classification
 multiclass problem,Multiclass Problem
 Multi-class problem,Multiclass Problem
 multiclass support vector machine,Multiclass SVM
-Multiclass SVM,Multiclass SVM
 multi-classification,Multi-Classification
 multi-classifier,Multi-Classifier
 multiclassifiers,Multi-Classifier
@@ -6636,7 +5499,6 @@ MULTICLASSIFIER SYSTEMS,Multi-Classifier System
 multiclassifier systems,Multi-Classifier System
 multi-classifier systems,Multi-Classifier System
 Multi-column architecture,Multi-Column Architecture
-Multi-Column Deep Neural Networks,Multi-Column Deep Neural Networks
 Multi-digit numbers,Multi-Digit Numbers
 multi-dimensional data visualization,Multi-Dimensional Data Visualization
 Multidimensional Long Short Term Memory,Multi-Dimensional Long-Short Term Memory
@@ -6645,7 +5507,6 @@ multidimensional long short-term memory networks,Multi-Dimensional Long-Short Te
 multi-dimensional long-short term memory network,Multi-Dimensional Long-Short Term Memory Network
 multidimensional scaling,Multi-Dimensional Scaling
 multidirectional LSTM,Multi-Directional LSTM
-Multidomain Stability Analysis,Multidomain Stability Analysis
 multi-exemplar,Multi-Exemplar
 multi-expert combination,Multi-Expert Combination
 MULTIEXPERT SYSTEM,Multi-Expert System
@@ -6656,9 +5517,7 @@ multifeature,Multi-Feature
 multi-feature,Multi-Feature
 Multi-font type,Multi-Font Type
 multi-fractal,Multi-Fractal
-Multi-Fractal Features,Multi-Fractal Features
 Multi-Gradient elongated quinary patterns,Multi-Gradient Elongated Quinary Patterns
-Multigrams,Multigrams
 multi-label self-organizing map,Multi-Label Self-Organizing Map
 Multilanguage,Multi-Language
 Multi-language,Multi-Language
@@ -6668,7 +5527,6 @@ MULTILAYER FEEDFORWARD NETWORKS,Multilayer Feed Forward Neural Network
 MULTILAYER NEURAL NETWORK,Multilayer Neural Network
 multilayer neural network,Multilayer Neural Network
 MULTILAYER PERCEPTRON,Multilayer Perceptron
-Multilayer Perceptron,Multilayer Perceptron
 multilayer perceptron,Multilayer Perceptron
 Multi-Layer Perceptron,Multilayer Perceptron
 Multi-layer perceptron,Multilayer Perceptron
@@ -6685,7 +5543,6 @@ multilevel classification,Multi-Level Classification
 multilevel feature combination,Multi-Level Feature Combination
 Multi-level neural network,Multi-Level Neural Network
 multi-level quick link,Multi-Level Quick Link
-Multilingual,Multilingual
 multilingual,Multilingual
 Multi-lingual,Multilingual
 multi-lingual,Multilingual
@@ -6695,7 +5552,6 @@ Multilingual document analysis,Multilingual Document Analysis
 Multi-lingual documents,Multilingual Documents
 Multilingual handwritten text recognition,Multilingual Handwritten Text Recognition
 Multilingual interoperation,Multilingual Interoperation
-Multilingual OCR,Multilingual OCR
 multilingual OCR,Multilingual OCR
 multilingual processing,Multilingual Processing
 multilingualism,Multilingualism
@@ -6723,7 +5579,6 @@ Multimodal systems,Multimodal Systems
 Multi-modal writing instruction,Multimodal Writing Instruction
 multimodality,Multimodality
 Multi-model selection,Multi-Model Selection
-Multi-Modeling,Multi-Modeling
 MULTINOMIAL LOGISTIC-REGRESSION,Multinomial Logistic-Regression
 Multi-objective evolutionary algorithm,Multi-Objective Evolutionary Algorithm
 MULTIOBJECTIVE EVOLUTIONARY ALGORITHMS,Multi-Objective Evolutionary Algorithm
@@ -6746,7 +5601,6 @@ MULTIPLE CLASSIFIER SYSTEMS,Multiple Classifier System
 Multiple classifier systems,Multiple Classifier System
 multiple classifier systems,Multiple Classifier System
 MULTIPLE CLASSIFIERS,Multiple Classifiers
-Multiple Classifiers,Multiple Classifiers
 Multiple classifiers,Multiple Classifiers
 multiple classifiers,Multiple Classifiers
 multiple classifiers systems,Multiple Classifiers Systems
@@ -6779,7 +5633,6 @@ multiple-expert-classifier,Multiple-Expert-Classifier
 Multiplication table,Multiplication Table
 multiplicative gamma process,Multiplicative Gamma Process
 multiplying circuits,Multiplying Circuits
-Multi-Process,Multi-Process
 multi-resolution,Multi-Resolution
 multi-resolution analysis,Multi-Resolution Analysis
 multiresolution features,Multiresolution Features
@@ -6813,7 +5666,6 @@ multistage recognition of characters,Multistage Recognition Of Characters
 Multi-stage text recognition,Multi-Stage Text Recognition
 Multi-stream,Multi-Stream
 multi-stream,Multi-Stream
-Multi-Stream Hidden Markov Model,Multi-Stream Hidden Markov Model
 Multi-stream HMM,Multi-Stream Hidden Markov Model
 multi-stream HMM,Multi-Stream Hidden Markov Model
 Multi-stream HMMs,Multi-Stream Hidden Markov Model
@@ -6826,15 +5678,12 @@ Multi-Task Learning (MTL),Multi-Task Learning
 Multi-touch,Multi-Touch
 Multi-touch desk,Multi-Touch Desk
 multi-touch gesture,Multi-Touch Gesture
-Multivariate Regression,Multivariate Regression
 multivariate semi-wrapped Gaussian distribution,Multivariate Semi-Wrapped Gaussian Distribution
 Multi-view clustering,Multi-View Clustering
 Multiview learning,Multi-View Learning
 multiview learning,Multi-View Learning
 multi-view learning,Multi-View Learning
-Multrenets,Multrenets
 Mumford-Shah model,Mumford-Shah Model
-Muscle Activation Profile,Muscle Activation Profile
 Muscle computer interface,Muscle Computer Interface
 muscle computer interface,Muscle Computer Interface
 MUSCLE FATIGUE,Muscle Fatigue
@@ -6843,29 +5692,19 @@ muscle-computer interface,Muscle-Computer Interface
 MUSCLES,Muscles
 musculoskeletal disorders,Musculoskeletal Disorders
 MUSIC,Music
-Music,Music
 music,Music
 music interfaces,Music Interfaces
 Music manuscripts,Music Manuscripts
-Music Score Documents,Music Score Documents
 music score recognition,Music Score Recognition
-Music Spotting,Music Spotting
 Music symbol recognition,Music Symbol Recognition
-Music Symbols,Music Symbols
 musical manuscript analysis,Musical Manuscript Analysis
-Musical Motifs Extraction,Musical Motifs Extraction
 Musical score,Musical Score
 mutation,Mutation
 mutual information,Mutual Information
-MWRCNN,MWRCNN
-MXene,MXene
 MYOELECTRIC CONTROL,Myoelectric Control
 myoelectric control,Myoelectric Control
 myoelectric signals,Myoelectric Signals
-NAE,NAE
-Naive Bayes,Naive Bayes
 naive Bayes,Naive Bayes
-Naive Bayes Classification,Naive Bayes Classification
 Naive Bayes classifier,Naive Bayes Classifier
 Naive Bayes Classifiers,Naive Bayes Classifier
 naive Bayesian,Naive Bayesian
@@ -6875,18 +5714,13 @@ NAME RECOGNITION,Name Recognition
 NAMED ENTITY RECOGNITION,Named Entity Recognition
 Named entity recognition,Named Entity Recognition
 named entity recognition,Named Entity Recognition
-Nanoelectronics,Nanoelectronics
 NAO robot,Nao Robot
 NARRATIVES,Narratives
-Naskh,Naskh
-Nastaleeq,Nastaleeq
 Nasta'liq,Nastaleeq
-Native Apps,Native Apps
 Natural history,Natural History
 natural language,Natural Language
 natural languages,Natural Language
 natural language interfaces,Natural Language Interfaces
-Natural Language Processing,Natural Language Processing
 Natural language processing,Natural Language Processing
 natural language processing,Natural Language Processing
 NLP,Natural Language Processing
@@ -6899,15 +5733,10 @@ natural writing processing,Natural Writing Processing
 naturalness,Naturalness
 Nature inspired,Nature Inspired
 Nature-inspired methods,Nature-Inspired Methods
-Navigation,Navigation
 N-best decoding,N-Best Decoding
-NBNN classifier,NBNN classifier
 n-class,N-Class
-NDSOFM,NDSOFM
 near optimal parameters,Near Optimal Parameters
 Nearest centroid,Nearest Centroid
-Nearest Mapping Algorithm,Nearest Mapping Algorithm
-Nearest Neighbor,Nearest Neighbor
 Nearest neighbor,Nearest Neighbor
 nearest neighbor,Nearest Neighbor
 NEAREST NEIGHBORS,Nearest Neighbor
@@ -6917,13 +5746,11 @@ nearest neighbour,Nearest Neighbor
 nearest-neighbours,Nearest Neighbor
 nearest neighbor classification,Nearest Neighbor Classification
 NEAREST NEIGHBOR CLASSIFIER,Nearest Neighbor Classifier
-Nearest Neighbor Classifier,Nearest Neighbor Classifier
 nearest neighbor classifier,Nearest Neighbor Classifier
 nearest-neighbor classifier,Nearest Neighbor Classifier
 nearest neighbor matching,Nearest Neighbor Matching
 Nearest Neighbour Network,Nearest Neighbor Network
 nearest neighbor search,Nearest Neighbor Search
-Nearest Neighborhood Classifier,Nearest Neighborhood Classifier
 Nearest stroke pixel,Nearest Stroke Pixel
 NEAREST-NEIGHBOR RULE,Nearest-Neighbor Rule
 negative data,Negative Data
@@ -6934,16 +5761,13 @@ Negative training,Negative Training
 NEIGHBOR,Neighbor
 neighborhood rough set,Neighborhood Rough Set
 NEOCOGNITRON,Neocognitron
-Neocognitron,Neocognitron
 neocognitron,Neocognitron
 neonatal alertness state,Neonatal Alertness State
 neonatal behavioral assessment scale (NBAS),Neonatal Behavioral Assessment Scale
 neonatal intensive care unit (NICU),Neonatal Intensive Care Unit
 neonatal unit,Neonatal Unit
 Nepali handwritten datasets,Nepali Handwritten Datasets
-Nephrology,Nephrology
 NERVOUS-SYSTEM,Nervous-System
-Net Averaging,Net Averaging
 NETWORK,Network
 NETWORK ARCHITECTURE,Network Architecture
 network integration based on supervised learning (NISL),Network Integration Based On Supervised Learning
@@ -6962,7 +5786,6 @@ neural architecture,Neural Architecture
 neural architecture optimization,Neural Architecture Optimization
 Neural Architecture Search (NAS),Neural Architecture Search
 NEURAL BASES,Neural Bases
-Neural Codes,Neural Codes
 neural gas,Neural Gas
 NEURAL HARDWARE,Neural Hardware
 neural language model,Neural Language Model
@@ -6993,7 +5816,6 @@ Neural Network,Neural Networks
 Neural network,Neural Networks
 neural network,Neural Networks
 NEURAL NETWORKS,Neural Networks
-Neural Networks,Neural Networks
 Neural networks,Neural Networks
 neural networks,Neural Networks
 Neural networks (NNs),Neural Networks
@@ -7002,7 +5824,6 @@ NEURAL-NETWORKS,Neural Networks
 NN,Neural Networks
 neural networks and fuzzy logic,Neural Networks And Fuzzy Logic
 Neural text generation,Neural Text Generation
-Neuroevolution,Neuroevolution
 neuroevolution,Neuroevolution
 Neuro-evolution,Neuroevolution
 Neuro Fuzzy Systems,Neuro-Fuzzy System
@@ -7010,12 +5831,10 @@ Neuro-fuzzy system,Neuro-Fuzzy System
 neuro-fuzzy system,Neuro-Fuzzy System
 neuro-fuzzy systems,Neuro-Fuzzy System
 neuroimaging,Neuroimaging
-Neuromorphic Computing,Neuromorphic Computing
 neuromorphic computing,Neuromorphic Computing
 neuromorphic devices,Neuromorphic Devices
 neuromotor model,Neuromotor Model
 Neuromuscular disorder,Neuromuscular Disorder
-Neuromuscular Modelling,Neuromuscular Modelling
 neuromuscular networks,Neuromuscular Networks
 neuromuscular systems,Neuromuscular Systems
 neuron,Neurons
@@ -7027,7 +5846,6 @@ neutrosophic rule-based verification system,Neutrosophic Rule-Based Verification
 new fitness function,New Fitness Function
 new particle coding,New Particle Coding
 New structure for Persian (Farsi) cheques,New Structure For Persian (Farsi) Cheques
-New Tai Lue,New Tai Lue
 New Tai Lue characters,New Tai Lue Characters
 news video,News Video
 Newspaper,Newspapers
@@ -7039,21 +5857,11 @@ n-gram model,N-Gram Model
 N-GRAM,n-grams
 n-gram,n-grams
 N-grams,n-grams
-n-grams,n-grams
-NHEXAS,NHEXAS
 Niblack's thresholding,Niblack's Thresholding
-Niche,Niche
 niching methods,Niching Methods
-NIR,NIR
-NIST,NIST
-NIST database,NIST database
-NIT dataset,NIT dataset
-NMF,NMF
-NNC,NNC
 node weight,Node Weight
 nodes,Nodes
 NOISE,Noise
-Noise,Noise
 noise,Noise
 noise and outliers,Noise And Outliers
 NOISE INJECTION,Noise Injection
@@ -7090,12 +5898,10 @@ non-linear features,Non-Linear Features
 Non-linear handwriting processing,Non-Linear Handwriting Processing
 Nonlinear model,Non-Linear Model
 NONLINEAR NORMALIZATION,Nonlinear Normalization
-Nonlinear Normalization,Nonlinear Normalization
 Nonlinear normalization,Nonlinear Normalization
 NONLINEAR NORMALIZATION METHOD,Nonlinear Normalization Method
 nonlinear regression,Nonlinear Regression
 NONLINEAR SHAPE NORMALIZATION,Nonlinear Shape Normalization
-Nonlinear SVM RBF Kernel,Nonlinear SVM RBF Kernel
 Nonlinear system identification,Nonlinear System Identification
 Nonlinearly separable,Nonlinearly Separable
 non-local means,Non-Local Means
@@ -7110,7 +5916,6 @@ non-recognition document format,Non-Recognition Document Format
 nonredundant Stockwell transform,Nonredundant Stockwell Transform
 NONRIGID MOTION,Nonrigid Motion
 NONRIGID SHAPES,Nonrigid Shapes
-Non-Symmetric Half-Plan,Non-Symmetric Half-Plan
 NON-TEXT CLASSIFICATION,Non-Text Classification
 nonuniform intraword distances,Nonuniform Intraword Distances
 Non-verbal,Non-Verbal
@@ -7118,7 +5923,6 @@ Normal coordinate vectors,Normal Coordinate Vectors
 normalisation,Normalisation
 normalised mean error distance,Normalised Mean Error Distance
 NORMALIZATION,Normalization
-Normalization,Normalization
 normalization,Normalization
 normalization-cooperated gradient feature (NCGF),Normalization-Cooperated Gradient Feature
 Normalized compression distance,Normalized Compression Distance
@@ -7127,19 +5931,14 @@ Normalized cross-correlation,Normalized Cross Correlation
 normalized cross-correlation,Normalized Cross Correlation
 normalized mutual information,Normalized Mutual Information
 Normalized poly kernel,Normalized Poly Kernel
-NOSQL DATABASE,NOSQL DATABASE
 NOTATION,Notation
 notch elimination,Notch Elimination
-Notes Extraction,Notes Extraction
 Notes extraction,Notes Extraction
 NOTETAKING,Note-Taking
 NOTE-TAKING,Note-Taking
 note-taking style,Note-Taking Style
-Novelty,Novelty
 N-Pen plus plus features,N-Pen++ Features
-NSGA II,NSGA II
 NSGA-II,Nsga-Ii
-NSHP-HMM,NSHP-HMM
 NTCP MODELS,NTCP Models
 n-tuple direction feature,N-Tuple Direction Feature
 n-tuple pattern recognition method,N-Tuple Pattern Recognition Method
@@ -7172,51 +5971,39 @@ numerical recognition,Numerical Recognition
 numerical sequences,Numerical Sequences
 NUMERICAL STRINGS,Numerical Strings
 Numerical strings,Numerical Strings
-NumtaDB,NumtaDB
 NumtaDB dataset,NumtaDB Dataset
 nyushu,Nyushu
-OBIE,OBIE
-oBIFs,oBIFs
 OBJECT,Object
-Object Detection,Object Detection
 Object detection,Object Detection
 object detection,Object Detection
 object detector,Object Detector
 OBJECT RECOGNITION,Object Recognition
-Object Recognition,Object Recognition
 Object recognition,Object Recognition
 object recognition,Object Recognition
 OBJECTS,Objects
 Occam's razor,Occam's Razor
 occlusion dictionary,Occlusion Dictionary
-OCCR,OCCR
 Occupational therapy,Occupational Therapy
 OCR accuracy,OCR Accuracy
 OCR algorithms benchmarking,OCR Algorithms Benchmarking
-OCR Applications,OCR Applications
 OCR correction,OCR Correction
 OCR Error correction,OCR Correction
 OCR error-generation model,OCR Error-Generation Model
 OCR handprint recognition,OCR Handprint Recognition
 OCR of multi-script document,OCR Of Multi-Script Document
-OCR Optimization,OCR Optimization
 OCR post-processing,OCR Post-Processing
 OCR SYSTEM,OCR System
 OCR tool,OCR Tool
 OCR UNCONSTRAINED OPTIMIZATION,OCR Unconstrained Optimization
-OCRopus,OCRopus
 OCULAR MICROTREMOR,Ocular Microtremor
-Odia,Odia
 Odia character recognition,Odia Character Recognition
 Odia compound characters,Odia Compound Characters
 Odia language,Odia Language
 Odia numeral,Odia Numerals
 Odia numerals,Odia Numerals
 Odia script,Odia Script
-OFD,OFD
 off-lexicon,Off-Lexicon
 Off-lexicon recognition,Off-Lexicon Recognition
-Offline,Offline
 offline,Offline
 OFF-LINE,Offline
 Off-line,Offline
@@ -7230,7 +6017,6 @@ Offline Arabic handwriting recognition,Offline Arabic Handwriting Recognition
 Offline arabic handwriting recognition,Offline Arabic Handwriting Recognition
 offline Arabic handwriting recognition,Offline Arabic Handwriting Recognition
 Off-line Arabic Handwriting Recognition,Offline Arabic Handwriting Recognition
-Offline Arabic Handwritten Recognition,Offline Arabic Handwritten Recognition
 Offline Arabic handwritten recognition,Offline Arabic Handwritten Recognition
 offline arabic handwritting recognition,Offline Arabic Handwritting Recognition
 Off-line Automatic Assessment System,Off-Line Automatic Assessment System
@@ -7258,7 +6044,6 @@ off-line handwriting,Offline Handwriting
 off-line handwriting analysis,Offline Handwriting Analysis
 Offline handwriting generation,Offline Handwriting Generation
 OFFLINE HANDWRITING RECOGNITION,Offline Handwriting Recognition
-Offline Handwriting Recognition,Offline Handwriting Recognition
 Offline Handwriting recognition,Offline Handwriting Recognition
 Offline handwriting recognition,Offline Handwriting Recognition
 offline handwriting recognition,Offline Handwriting Recognition
@@ -7272,7 +6057,6 @@ offline handwritten,Offline Handwritten
 off-line handwritten Arabic word,Offline Handwritten Arabic Word
 Offline handwritten character,Offline Handwritten Character
 offline handwritten character,Offline Handwritten Character
-Offline Handwritten Character Recognition,Offline Handwritten Character Recognition
 Offline handwritten character recognition,Offline Handwritten Character Recognition
 offline handwritten character recognition,Offline Handwritten Character Recognition
 Off-line handwritten character recognition,Offline Handwritten Character Recognition
@@ -7290,12 +6074,10 @@ offline handwritten mathematical expression,Offline Handwritten Mathematical Exp
 offline handwritten mathematical expression recognition,Offline Handwritten Mathematical Expression Recognition
 Offline handwritten recognition,Offline Handwritten Recognition
 Off-line Handwritten Recognition,Offline Handwritten Recognition
-Offline Handwritten Signature Verification,Offline Handwritten Signature Verification
 Off-line handwritten signature verification,Offline Handwritten Signature Verification
 off-line Handwritten Signature Verification,Offline Handwritten Signature Verification
 off-line handwritten signature verification,Offline Handwritten Signature Verification
 offline handwritten signatures verification systems,Offline Handwritten Signatures Verification Systems
-Offline Handwritten Telugu Character Recognition,Offline Handwritten Telugu Character Recognition
 Offline handwritten text line recognition,Offline Handwritten Text Line Recognition
 Offline handwritten text recognition,Offline Handwritten Text Recognition
 offline handwritten text recognition,Offline Handwritten Text Recognition
@@ -7305,7 +6087,6 @@ OFF-LINE IDENTIFICATION,Offline Identification
 Offline musical symbol recognition,Offline Musical Symbol Recognition
 Off-line optical character recognition,Offline Optical Character Recognition
 OFFLINE RECOGNITION,Offline Recognition
-Offline Recognition,Offline Recognition
 Offline recognition,Offline Recognition
 offline recognition,Offline Recognition
 OFF-LINE RECOGNITION,Offline Recognition
@@ -7313,7 +6094,6 @@ Off-line recognition,Offline Recognition
 off-line recognition,Offline Recognition
 offline self-learning application,Offline Self-Learning Application
 OFFLINE SIGNATURE VERIFICATION,Offline Signature Verification
-Offline Signature Verification,Offline Signature Verification
 Offline signature Verification,Offline Signature Verification
 Offline signature verification,Offline Signature Verification
 offline signature verification,Offline Signature Verification
@@ -7336,10 +6116,6 @@ Off-line word recognition,Offline Word Recognition
 off-line writer verification,Offline Writer Verification
 off-line writing recognition,Offline Writing Recognition
 OF-HEARING STUDENTS,Of-Hearing Students
-OHASD dataset,OHASD dataset
-OHKC,OHKC
-OHR,OHR
-OIHACDB,OIHACDB
 old manuscript recognition,Old Manuscript Recognition
 olfactory signal recognition,Olfactory Signal Recognition
 Omni font recognition,Omni Font Recognition
@@ -7350,7 +6126,6 @@ on-board processing,On-Board Processing
 On-device learning,On-Device Learning
 on-device processing,On-Device Processing
 one versus all (OVA),One Versus All
-One-Class Classification,One-Class Classification
 One-class classification,One-Class Classification
 One-class classifiers,One-Class Classifiers
 One-shot learning,One-Shot Learning
@@ -7358,7 +6133,6 @@ one-shot learning,One-Shot Learning
 one-stroke cursive character,One-Stroke Cursive Character
 one-versus-all classifiers,One-Versus-All Classifiers
 ONLINE,Online
-Online,Online
 online,Online
 On-line,Online
 on-line,Online
@@ -7367,17 +6141,14 @@ on-line adaptation,Online Adaptation
 Online and offline features,Online And Offline Features
 online and offline handwriting recognition,Online And Offline Handwriting Recognition
 online and offline information,Online And Offline Information
-Online Arabic Handwriting,Online Arabic Handwriting
 Online Arabic handwriting,Online Arabic Handwriting
 Online Arabic handwriting recognitio,Online Arabic Handwriting Recognition
-Online Arabic Handwriting Recognition,Online Arabic Handwriting Recognition
 Online Arabic handwriting recognition,Online Arabic Handwriting Recognition
 On-line Arabic handwriting recognition,Online Arabic Handwriting Recognition
 online Arabic handwritten recognition,Online Arabic Handwritten Recognition
 Online Arabic recognition system,Online Arabic Recognition System
 online authentication,Online Authentication
 ONLINE CHARACTER RECOGNITION,Online Character Recognition
-Online Character Recognition,Online Character Recognition
 Online character recognition,Online Character Recognition
 online character recognition,Online Character Recognition
 On-line character recognition,Online Character Recognition
@@ -7397,21 +6168,18 @@ On-line game,Online Game
 On-line hand-drawn structured document recognition,Online Hand-Drawn Structured Document Recognition
 On line Handwriting,Online Handwriting
 Onlilne Handwriting,Online Handwriting
-Online Handwriting,Online Handwriting
 Online handwriting,Online Handwriting
 online handwriting,Online Handwriting
 On-Line Handwriting,Online Handwriting
 On-line Handwriting,Online Handwriting
 On-line handwriting,Online Handwriting
 on-line handwriting,Online Handwriting
-Online Handwriting Analysis,Online Handwriting Analysis
 on-line handwriting Arabic word recognition segmentation free,Online Handwriting Arabic Word Recognition Segmentation Free
 online handwriting database,Online Handwriting Database
 on-line handwriting database,Online Handwriting Database
 online handwriting Farsi character and numbers recognition,Online Handwriting Farsi Character And Numbers Recognition
 on-line handwriting modeling,Online Handwriting Modeling
 ONLINE HANDWRITING RECOGNITION,Online Handwriting Recognition
-Online Handwriting Recognition,Online Handwriting Recognition
 Online Handwriting recognition,Online Handwriting Recognition
 Online handwriting recognition,Online Handwriting Recognition
 online handwriting recognition,Online Handwriting Recognition
@@ -7424,7 +6192,6 @@ Online handwritten,Online Handwritten
 online handwritten Arabic character recognition,Online Handwritten Arabic Character Recognition
 Online handwritten character database,Online Handwritten Character Database
 ONLINE HANDWRITTEN CHARACTER RECOGNITION,Online Handwritten Character Recognition
-Online Handwritten Character Recognition,Online Handwritten Character Recognition
 Online handwritten character recognition,Online Handwritten Character Recognition
 online handwritten character recognition,Online Handwritten Character Recognition
 on-line handwritten character recognition,Online Handwritten Character Recognition
@@ -7453,9 +6220,7 @@ Online learning,Online Learning
 On-line learning,Online Learning
 on-line monitoring,Online Monitoring
 Online overlaid Chinese handwriting,Online Overlaid Chinese Handwriting
-Online Preprocessing,Online Preprocessing
 ONLINE RECOGNITION,Online Recognition
-Online Recognition,Online Recognition
 Online recognition,Online Recognition
 online recognition,Online Recognition
 On-line recognition,Online Recognition
@@ -7463,7 +6228,6 @@ on-line recognition,Online Recognition
 Online recognition of handwriting,Online Recognition Of Handwriting
 Online recognition of handwritten strokes,Online Recognition Of Handwritten Strokes
 online resource for patient counseling,Online Resource For Patient Counseling
-Online Script Recognition,Online Script Recognition
 on-line script recognition,Online Script Recognition
 on-line segmentation,Online Segmentation
 online signature,Online Signature
@@ -7472,7 +6236,6 @@ on-line signature,Online Signature
 on-line signature biometrics,Online Signature Biometrics
 On-line signature recognition,Online Signature Recognition
 ONLINE SIGNATURE VERIFICATION,Online Signature Verification
-Online Signature Verification,Online Signature Verification
 Online signature verification,Online Signature Verification
 online signature verification,Online Signature Verification
 On-line Signature Verification,Online Signature Verification
@@ -7488,14 +6251,12 @@ online text recognition,Online Text Recognition
 on-line text segmentation,Online Text Segmentation
 Online text-independent writer identification,Online Text-Independent Writer Identification
 online trajectory recovery,Online Trajectory Recovery
-Online Urdu Character Recognition,Online Urdu Character Recognition
 online Vietnamese handwritten character recognition,Online Vietnamese Handwritten Character Recognition
 online words,Online Words
 Online writer identification,Online Writer Identification
 online writer identification system,Online Writer Identification System
 online-to-offline signature conversion,Online-To-Offline Signature Conversion
 ONTOLOGIES,Ontologies
-Ontology,Ontology
 ontology,Ontology
 open data,Open Data
 Open handwritten signature identification system,Open Handwritten Signature Identification System
@@ -7507,18 +6268,11 @@ open source tool,Open Source Tool
 open vocabulary,Open Vocabulary
 open vocabulary recognition,Open Vocabulary Recognition
 open-bigram coding,Open-Bigram Coding
-OpenCL,OpenCL
 open CV,OpenCV
-OpenCV,OpenCV
-OpenHaRT,OpenHaRT
-OpenHaRT database,OpenHaRT database
-OpenType (R) font,OpenType (R) font
 operand truncation,Operand Truncation
 OPERATIONS,Operations
 Operator design,Operator Design
-Operator Performance Assessment,Operator Performance Assessment
 OPERATORS,Operators
-OPF,OPF
 Opposition-based learning,Opposition-Based Learning
 Optical character,Optical Character
 OCR,Optical Character Recognition
@@ -7527,7 +6281,6 @@ OCR (Optical Character Recognition),Optical Character Recognition
 OCR (optical character recognition),Optical Character Recognition
 OCR (Optical character recognition) etc,Optical Character Recognition
 OPTICAL CHARACTER RECOGNITION,Optical Character Recognition
-Optical Character Recognition,Optical Character Recognition
 Optical character Recognition,Optical Character Recognition
 Optical character recognition,Optical Character Recognition
 optical character recognition,Optical Character Recognition
@@ -7548,12 +6301,9 @@ optical handwritten character recognition,Optical Handwritten Character Recognit
 Optical imaging,Optical Imaging
 OPTICAL INSPECTION SYSTEM,Optical Inspection System
 Optical model,Optical Models
-Optical Models,Optical Models
 OMR (Optical Music Recognition),Optical Music Recognition
-Optical Music Recognition,Optical Music Recognition
 Optical music recognition,Optical Music Recognition
 optical music recognition,Optical Music Recognition
-Optical Music Symbol Recognition,Optical Music Symbol Recognition
 OPTICAL RECOGNITION,Optical Recognition
 optical recognition,Optical Recognition
 Optical scan,Optical Scan
@@ -7564,22 +6314,17 @@ OPTICAL-FLOW,Optical-Flow
 Optimal assignment,Optimal Assignment
 optimal defuzzification,Optimal Defuzzification
 OPTIMAL DESIGN OF REFERENCE MODELS,Optimal Design Of Reference Models
-optimal DTW algorithm,optimal DTW algorithm
 optimal zone selection,Optimal Zone Selection
 OPTIMAL-DESIGN,Optimal-Design
 OPTIMALITY,Optimality
 optimisation,Optimization
 OPTIMIZATION,Optimization
-Optimization,Optimization
 optimization,Optimization
 OPTIMIZED DEFUZZIFICATION,Optimized Defuzzification
-Optimized leaky ReLU,Optimized leaky ReLU
 optimizer,Optimizers
-Optimizers,Optimizers
 optimizers,Optimizers
 optimizing segmentation hypotheses,Optimizing Segmentation Hypotheses
 OPTIMUM DESIGN,Optimum Design
-Optimum-Path Forest,Optimum-Path Forest
 Optimum-path forest,Optimum-Path Forest
 OPTION,Option
 oracle bone inscriptions,Oracle Bone Inscriptions
@@ -7595,33 +6340,27 @@ orientation features,Orientation Features
 oriented bounding box,Oriented Bounding Box
 oriented Gaussian filters,Oriented Gaussian Filters
 ORIENTED GRADIENTS,Oriented Gradients
-Oriented Gradients,Oriented Gradients
 oriented gradients,Oriented Gradients
 oriented sliding window,Oriented Sliding Window
 Origin identification,Origin Identification
 original credence,Original Credence
-Oriy,Oriy
 Oriya script,Oriya Script
 Orthogonal Gaussian mixture model (OGMM),Orthogonal Gaussian Mixture Model
 orthogonal learning,Orthogonal Learning
 orthogonal linear discriminant analysis,Orthogonal Linear Discriminant Analysis
 orthogonal moments,Orthogonal Moments
 Orthogonal moments (OM),Orthogonal Moments
-orthogonal MST,orthogonal MST
 orthogonal polynomial series,Orthogonal Polynomial Series
 orthogonal polynomials,Orthogonal Polynomials
 orthogonality,Orthogonality
 ORTHOGRAPHIC CODING,Orthographic Coding
 orthographic coding,Orthographic Coding
 orthographic representation,Orthographic Representation
-Orthography,Orthography
 OSCILLATORY HANDWRITING MODEL,Oscillatory Handwriting Model
 ostracon,Ostracon
-Otsu's Thresholding,Otsu's Thresholding
 Out of vocabulary detection and recovery,Out Of Vocabulary Detection And Recovery
 out of vocabulary word,Out Of Vocabulary Word
 outlier,Outlier
-Outlier Detection,Outlier Detection
 outlier detection,Outlier Detection
 outlier rejection,Outlier Rejection
 Out-of-vocabulary,Out-Of-Vocabulary
@@ -7635,7 +6374,6 @@ overlap clustering,Overlap Clustering
 overlapped handwriting,Overlapped Handwriting
 overlapped handwriting recognition,Overlapped Handwriting Recognition
 overlapped handwritten digits,Overlapped Handwritten Digits
-Overlapping,Overlapping
 overlapping components,Overlapping Components
 Overlapping digit recognition,Overlapping Digit Recognition
 Overlapping digit separation,Overlapping Digit Separation
@@ -7643,17 +6381,12 @@ Overlapping handwriting recognition,Overlapping Handwriting Recognition
 Overlapping handwriting seperation,Overlapping Handwriting Seperation
 Over-segmentation,Over-Segmentation
 over-segmentation,Over-Segmentation
-Overview,Overview
-Ownership,Ownership
 OXIDE,Oxide
 oxygen vacancy,Oxygen Vacancy
-Padding,Padding
 page analysis,Page Analysis
 Page dewarping,Page Dewarping
-Page Rank,Page Rank
 Page replacement algorithm,Page Replacement Algorithm
 PAGE SEGMENTATION,Page Segmentation
-Page Segmentation,Page Segmentation
 Page segmentation,Page Segmentation
 page segmentation,Page Segmentation
 Page-level script identification,Page-Level Script Identification
@@ -7663,13 +6396,9 @@ pairwise classification,Pairwise Classification
 Pair-wise discrimination,Pair-Wise Discrimination
 pairwise neural networks,Pairwise Neural Networks
 Palaeography,Paleography
-Paleography,Paleography
 PALI,Pali
-Pali,Pali
-Pali Cards,Pali Cards
 Palm leaf character recognition,Palm Leaf Character Recognition
 Palm leaf character recognition (PLCR),Palm Leaf Character Recognition
-Palm Leaf Manuscript,Palm Leaf Manuscript
 palm leaf manuscript,Palm Leaf Manuscript
 Palm-leaf manuscript,Palm Leaf Manuscript
 palm leaf manuscript images,Palm Leaf Manuscript Images
@@ -7687,12 +6416,10 @@ parabola curve fitting,Parabola Curve Fitting
 Parabola curve fitting based features,Parabola Curve Fitting Based Features
 paraconsistent logic,Paraconsistent Logic
 paragraph map,Paragraph Map
-Parallel,Parallel
 PARALLEL ARCHITECTURE,Parallel Architecture
 parallel architecture,Parallel Architecture
 parallel architectures,Parallel Architectures
 Parallel classifier combination,Parallel Classifier Combination
-Parallel Computer Architecture,Parallel Computer Architecture
 parallel labelling,Parallel Labelling
 Parallel patterns,Parallel Patterns
 PARALLEL PROCESSING,Parallel Processing
@@ -7719,12 +6446,10 @@ PARATHYROIDECTOMY,Parathyroidectomy
 PARENTING STRESS,Parenting Stress
 Parkinson 's disease,Parkinson's Disease
 Parkinson&#8217,Parkinson's Disease
-Parkinson's Disease,Parkinson's Disease
 Parkinson's disease,Parkinson's Disease
 Parkinson's disease (PD),Parkinson's Disease
 PARKINSONS-DISEASE,Parkinson's Disease
 s disease,Parkinson's Disease
-Parser,Parser
 Parsimonious HMM,Parsimonious Hmm
 parsing,Parsing
 parsing algorithm,Parsing Algorithm
@@ -7737,12 +6462,10 @@ part-based recognition,Part-Based Recognition
 partial hypothesis fusion,Partial Hypothesis Fusion
 Partial segmentation,Partial Segmentation
 Partial supervision,Partial Supervision
-Partial Words,Partial Words
 particle density model,Particle Density Model
 particle swarm algorithm,Particle Swarm Algorithm
 particle swarm optimisation,Particle Swarm Optimization
 PARTICLE SWARM OPTIMIZATION,Particle Swarm Optimization
-Particle Swarm Optimization,Particle Swarm Optimization
 Particle swarm optimization,Particle Swarm Optimization
 particle swarm optimization,Particle Swarm Optimization
 Particle Swarm Optimization (PSO),Particle Swarm Optimization
@@ -7751,13 +6474,10 @@ part-of-speech tagging,Part-Of-Speech Tagging
 POS tagging,Part-Of-Speech Tagging
 PARTS,Parts
 Parzen windows,Parzen Windows
-Pashto,Pashto
 Pashto characters recognition,Pashto Characters Recognition
 Pashto handwritten character recognition,Pashto Handwritten Character Recognition
 PASS,Pass
 passive tracking,Passive Tracking
-passive UHF RFID,passive UHF RFID
-Password Management,Password Management
 Patch alignment framework,Patch Alignment Framework
 patch classification,Patch Classification
 Patch discriminator,Patch Discriminator
@@ -7775,10 +6495,8 @@ patient registration,Patient Registration
 PATIENT SAFETY,Patient Safety
 PATTERN,Pattern
 pattern,Pattern
-Pattern Analysis,Pattern Analysis
 PATTERN CHARACTER RECOGNITION,Pattern Character Recognition
 PATTERN CLASSIFICATION,Pattern Classification
-Pattern Classification,Pattern Classification
 Pattern classification,Pattern Classification
 pattern classification,Pattern Classification
 the algorithms of pattern classification,Pattern Classification Algorithm
@@ -7793,7 +6511,6 @@ pattern mining,Pattern Mining
 Pattern of Local Gravitational Force (PLGF),Pattern Of Local Gravitational Force
 pattern primitives,Pattern Primitives
 PATTERN RECOGNITION,Pattern Recognition
-Pattern Recognition,Pattern Recognition
 Pattern recognition,Pattern Recognition
 pattern recognition,Pattern Recognition
 pattern reconition,Pattern Recognition
@@ -7807,28 +6524,12 @@ PATTERN SYNTHESIS,Pattern Synthesis
 PATTERN SYNTHESIS TECHNIQUE,Pattern Synthesis Technique
 PATTERN TRANSFORMATION,Pattern Transformation
 PATTERNS,Patterns
-Pause,Pause
 pause threshold,Pause Threshold
-Pausing,Pausing
 Pausing during writing,Pausing During Writing
-PAW,PAW
-PBIL,PBIL
-PCA,PCA
-PCANet,PCANet
-PCA-SVMNet,PCA-SVMNet
-PCS,PCS
-PD identification system,PD identification system
-PDE-based approach,PDE-based approach
-PDE-based image processing,PDE-based image processing
-PDEs,PDEs
-PDMS,PDMS
-PDMultiMC dataset,PDMultiMC dataset
-PDTDFB transform,PDTDFB transform
 Peak and Valley Point Identification,Peak And Valley Point Identification
 Peak extent features,Peak Extent Features
 peak signal-to-noise ratio,Peak Signal-To-Noise Ratio
 pedagogy,Pedagogy
-Pediatrics,Pediatrics
 PEN,Pen
 pen,Pen
 pen based applications,Pen Based Applications
@@ -7871,21 +6572,16 @@ perception,Perception
 PERCEPTION SIMULATION,Perception Simulation
 perceptive concept,Perceptive Concept
 PERCEPTRON,Perceptron
-Perceptron,Perceptron
-Perceptual Features,Perceptual Features
 perceptual features,Perceptual Features
-Perceptual Grouping,Perceptual Grouping
 PERCEPTUAL LOAD,Perceptual Load
 perceptual or perception-oriented,Perceptual Or Perception-Oriented
 perceptual-motor interactions,Perceptual-Motor Interactions
 Performace evaluation,Performace Evaluation
 PERFORMANCE,Performance
-Performance,Performance
 performance,Performance
 PERFORMANCE ANALYSIS,Performance Analysis
 performance assessment,Performance Assessment
 PERFORMANCE EVALUATION,Performance Evaluation
-Performance Evaluation,Performance Evaluation
 Performance evaluation,Performance Evaluation
 performance evaluation,Performance Evaluation
 performance improvement,Performance Improvement
@@ -7898,14 +6594,11 @@ PERIPHERAL PROCESSES,Peripheral Processes
 PERMUTATION ENTROPY,Permutation Entropy
 permutation entropy,Permutation Entropy
 perplexity,Perplexity
-Persian,Persian
 Persian alphabet,Persian Alphabet
 Persian and Arabic scripts,Persian And Arabic Scripts
 Persian characteristics,Persian Characteristics
-Persian Check Processing,Persian Check Processing
 Persian date,Persian Date
 Persian documents,Persian Documents
-Persian Handwriting,Persian Handwriting
 Persian handwriting,Persian Handwriting
 Persian handwriting database,Persian Handwriting Database
 Persian handwriting recognition,Persian Handwriting Recognition
@@ -7913,10 +6606,8 @@ Persian handwritten character recognition,Persian Handwritten Character Recognit
 Persian handwritten checks,Persian Handwritten Checks
 Persian handwritten database,Persian Handwritten Database
 Persian handwritten digit recognition,Persian Handwritten Digit Recognition
-Persian Handwritten Recognition,Persian Handwritten Recognition
 Persian handwritten word,Persian Handwritten Word
 Persian handwritten words recognition,Persian Handwritten Words Recognition
-Persian Isolated Digit Recognition,Persian Isolated Digit Recognition
 Persian language,Persian Language
 Persian offline recognition,Persian Offline Recognition
 Persian script segmentation,Persian Script Segmentation
@@ -7924,7 +6615,6 @@ Persian stroke concept,Persian Stroke Concept
 Persian strokes,Persian Strokes
 Persian language word recognition,Persian Words Recognition
 Persian words recognition,Persian Words Recognition
-Persian/Arabic Character Recognition,Persian/Arabic Character Recognition
 person authentication,Person Authentication
 PERSONAL DIGITAL ASSISTANT,Personal Digital Assistant
 personal digital assistants (PDAs),Personal Digital Assistant
@@ -7937,7 +6627,6 @@ PERSONALITY,Personality
 personality,Personality
 personality assessmen,Personality Assessmen
 personality traits,Personality Traits
-Personalization,Personalization
 PERSPECTIVE,Perspective
 PerTOHS theory,Pertohs Theory
 perturbation,Perturbation
@@ -7956,7 +6645,6 @@ Phonetic spelling variations,Phonetic Spelling Variations
 Phonological awareness,Phonological Awareness
 PHONOLOGICAL PROCESSING SKILLS,Phonological Processing Skills
 PHONOLOGY,Phonology
-Photo Annotation,Photo Annotation
 photonic computation,Photonic Computation
 phrase detection and recognition,Phrase Detection And Recognition
 phrase recognition,Phrase Recognition
@@ -7965,32 +6653,21 @@ physical structure,Physical Structure
 PHYSICIAN ORDER ENTRY,Physician Order Entry
 PHYSICIANS,Physicians
 Pictogram,Pictograms
-Pictograms,Pictograms
 PICTURE,Picture
 picture archiving and communication system,Picture Archiving And Communication System
 piecewise affine transform,Piecewise Affine Transform
-PIM,PIM
-Pipeline,Pipeline
 pipeline,Pipeline
 pipelines,Pipeline
 PIPELINE TOPOLOGY,Pipeline Topology
-Pipelining,Pipelining
-Pitch,Pitch
 Pitman-Yor process,Pitman-Yor Process
 pivot,Pivot
 pixel intensity,Pixel Intensity
 pixel prediction,Pixel Prediction
 Pixel-based method,Pixel-Based Method
 pixel-labelling,Pixel-Labelling
-Pixels,Pixels
-Plagiarism Detection,Plagiarism Detection
 plainchant,Plainchant
-Plastics,Plastics
 Plausibility measures,Plausibility Measures
-PM-Quad tree,PM-Quad tree
-PMUTs,PMUTs
 PNEUMONITIS,Pneumonitis
-PNN,PNN
 point classification,Point Classification
 point cloud data,Point Cloud Data
 point distribution model,Point Distribution Model
@@ -8003,7 +6680,6 @@ Polygonal approximation,Polygonal Approximation
 polygonal approximation,Polygonal Approximation
 Polygonal approximation based features,Polygonal Approximation Based Features
 POLYGONAL-APPROXIMATION,Polygonal-Approximation
-Polygonization,Polygonization
 polyline approximation process,Polyline Approximation Process
 POLYNOMIALS,Polynomials
 Pooling layer,Pooling Layer
@@ -8013,10 +6689,8 @@ popular compression algorithms,Popular Compression Algorithms
 popular Persian fonts,Popular Persian Fonts
 POSE,Pose
 poset,Poset
-Posets,Posets
 position maps,Position Maps
 position vector,Position Vector
-Positional Features,Positional Features
 positional relation,Positional Relation
 POSITIVE AFFECT,Positive Affect
 post processing,Post Processing
@@ -8024,19 +6698,16 @@ postal address recognition,Postal Address Recognition
 Postal automation,Postal Automation
 postal automation,Postal Automation
 postcard corpus,Postcard Corpus
-Post-CMOS,Post-CMOS
 postcode level,Postcode Level
 postcode recognition,Postcode Recognition
 Posterior distribution,Posterior Distribution
 Posterior probability,Posterior Probability
 Postprocessing,Post-Processing
 POST-PROCESSING,Post-Processing
-Post-Processing,Post-Processing
 Post-processing,Post-Processing
 post-processing,Post-Processing
 POSTPROCESSING ALGORITHM,Post-Processing Algorithm
 POST-PROCESSING SYSTEM,Post-Processing System
-Post-Recognition Lexicon Matching,Post-Recognition Lexicon Matching
 Poultry management,Poultry Management
 POWER,Power
 power,Power
@@ -8044,29 +6715,23 @@ power curve fitting,Power Curve Fitting
 Power curve fitting based features,Power Curve Fitting Based Features
 Power demand,Power Demand
 powerful discriminative features,Powerful Discriminative Features
-PPTRPRT,PPTRPRT
 PRACTICE,Practice
-Pragmatics,Pragmatics
-Precision,Precision
 precision,Precision
 preclassification,Preclassification
 predict personality,Predict Personality
 PREDICTION,Prediction
 Prediction rate,Prediction Rate
-Predictions,Predictions
 predictive power,Predictive Power
 PREDICTORS,Predictors
 prefix tree,Prefix Tree
 premotor cortex,Premotor Cortex
 Pre-printed documents,Pre-Printed Documents
 PREPROCESSING,Preprocessing
-Preprocessing,Preprocessing
 preprocessing,Preprocessing
 Pre-Processing,Preprocessing
 Pre-processing,Preprocessing
 pre-processing,Preprocessing
 preprocessing and feature extraction,Preprocessing And Feature Extraction
-Preprocessing Phase,Preprocessing Phase
 Preprocessing phase,Preprocessing Phase
 preprocessing phase,Preprocessing Phase
 preprocessing stage,Preprocessing Stage
@@ -8097,13 +6762,11 @@ PRIMARY-SCHOOL,Primary-School
 PRIMARY-SCHOOL CHILDREN,Primary-School Children
 primitive stroke,Primitive Stroke
 PRINCIPAL COMPONENT ANALYSIS,Principal Component Analysis
-Principal Component Analysis,Principal Component Analysis
 Principal component analysis,Principal Component Analysis
 principal component analysis,Principal Component Analysis
 Principal Component Analysis (PCA),Principal Component Analysis
 Principal component analysis (PCA),Principal Component Analysis
 principal component analysis (PCA),Principal Component Analysis
-Principal Curves,Principal Curves
 Principal curves,Principal Curves
 PRINCIPLE,Principle
 PRINCIPLES,Principles
@@ -8140,7 +6803,6 @@ probabilistic grammars,Probabilistic Grammars
 Probabilistic indexing,Probabilistic Indexing
 probabilistic inference,Probabilistic Inference
 probabilistic model,Probabilistic Model
-Probabilistic Neural Network,Probabilistic Neural Network
 Probabilistic Neural Network (PNN),Probabilistic Neural Network
 Probabilistic parsing,Probabilistic Parsing
 probabilistic prediction,Probabilistic Prediction
@@ -8167,7 +6829,6 @@ PROFICIENT,Proficient
 profile-HMM,Profile-HMM
 PROFILES,Profiles
 PROGNOSTICS,Prognostics
-Program Synthesis,Program Synthesis
 programming languages,Programming Languages
 PROGRAMS,Programs
 PROGRESS,Progress
@@ -8182,7 +6843,6 @@ Projection feature,Projection Features
 projection features,Projection Features
 Projection function,Projection Function
 Projection histogram,Projection Histogram
-Projection Profile,Projection Profile
 Projection profile,Projection Profile
 projection profile,Projection Profile
 projection profile analysis,Projection Profile Analysis
@@ -8190,22 +6850,16 @@ Projection profiles,Projection Profiles
 projection profiles,Projection Profiles
 projection-based features,Projection-Based Features
 PROJECTIONS,Projections
-Prolog,Prolog
 PROPAGATION,Propagation
-Proportional Invariant Feature,Proportional Invariant Feature
 Proportionality hypothesis,Proportionality Hypothesis
 propositionalisation,Propositionalisation
 protected neural containers,Protected Neural Containers
 PROTECTION,Protection
-Protocols,Protocols
-Prototype,Prototype
 prototype extraction,Prototype Extraction
 prototype learning,Prototype Learning
 PROTOTYPE OPTIMIZATION,Prototype Optimization
 prototypes,Prototypes
-Prototypicality,Prototypicality
 Proximal support vector machines,Proximal Support Vector Machines
-Pruning,Pruning
 pruning,Pruning
 PRUNING ALGORITHM,Pruning Algorithm
 PRUNING LARGE LEXICONS,Pruning Large Lexicons
@@ -8219,36 +6873,25 @@ pseudo-labeling,Pseudo-Labeling
 pseudo-line and pseudo-word extraction,Pseudo-Line And Pseudo-Word Extraction
 Pseudo-word,Pseudo-Word
 Pseudo-words,Pseudo-Word
-PSNR,PSNR
-PSOMLP-HWS,PSOMLP-HWS
 psychology,Psychology
-public AcTiV-R dataset,public AcTiV-R dataset
 public database,Public Database
 public databases,Public Database
-public dataset ALIF,public dataset ALIF
 pulse-coupled neural network,Pulse-Coupled Neural Network
 PURE ALEXIA,Pure Alexia
 pure clustering and classification,Pure Clustering And Classification
-Puzzle,Puzzle
 Pyramid Histogram of Gradient,Pyramid Histogram Of Gradient
 Pyramid histogram of gradients,Pyramid Histogram Of Gradient
 pyramid histogram of gradients,Pyramid Histogram Of Gradient
 Pyramid multi-level,Pyramid Multi-Level
-Python,Python
 python,Python
-PyTorch,PyTorch
-PZT,PZT
 Q-learning,Q-Learning
-QMQDF classifier,QMQDF classifier
 qtrees,Qtrees
 quad tree,Quad Tree
-Quadratic Classifiers,Quadratic Classifiers
 quadratic classifiers,Quadratic Classifiers
 Quadratic correlation,Quadratic Correlation
 QUADRATIC DISCRIMINANT FUNCTION,Quadratic Discriminant Function
 quadratic discriminant function,Quadratic Discriminant Function
 quadratic forms,Quadratic Forms
-Quadratics,Quadratics
 Quad-tree based feature extraction,Quad-Tree Based Feature Extraction
 Quad-tree based image segmentation,Quad-Tree Based Image Segmentation
 QUALITATIVE VISION,Qualitative Vision
@@ -8279,26 +6922,20 @@ QUASI-NEWTON METHODS,Quasi-Newton Methods
 quaternion-based complementary filter,Quaternion-Based Complementary Filter
 Query by String,Query By String
 Query fusion,Query Fusion
-Query Ranking,Query Ranking
 Query by Example,Query-By-Example
 query-by-example,Query-By-Example
 query-by-example word spotting,Query-By-Example Word Spotting
 question-answering,Question-Answering
-Questioned Document Examination,Questioned Document Examination
 Questioned document examination,Questioned Document Examination
 questioned document examination,Questioned Document Examination
 queuing theory,Queuing Theory
 Quickprop learning algorithm,Quickprop Learning Algorithm
 The Quran,Quran
 Quranic writing,Quranic Writing
-QUWI,QUWI
-QUWI Database,QUWI Database
 QUWI database,QUWI Database
-Radar,Radar
 radar,Radar
 Radar antennas,Radar Antennas
 radar image enhancing,Radar Image Enhancing
-Radial Basic Function,Radial Basic Function
 Radial Basis Function (RBF),Radial Basic Function
 radial basis functions,Radial Basic Function
 Radial Basis function Network,Radial Basis Function Network
@@ -8310,21 +6947,17 @@ radiograph,Radiograph
 "radiology and radiologists, design of radiological facilities","Radiology And Radiologists, Design Of Radiological Facilities"
 RADIOTHERAPY OUTCOMES,Radiotherapy Outcomes
 the Radon features,Radon Features
-Radon Transform,Radon Transform
 radon transform,Radon Transform
 The Radon transform,Radon Transform
 RAFAELI,Rafaeli
 Raman spectroscopy,Raman Spectroscopy
-Ramer-Douglas-Peucker,Ramer-Douglas-Peucker
 Rand index,Rand Index
 RANDOM FOREST,Random Forest
-Random Forest,Random Forest
 Random forest,Random Forest
 random forest,Random Forest
 random forests,Random Forest
 Random forest tree,Random Forest Tree
 random graph,Random Graph
-Random Hybrid Strokes,Random Hybrid Strokes
 random projected,Random Projected
 random search,Random Search
 random subspace method,Random Subspace Method
@@ -8332,7 +6965,6 @@ RANDOM-FIELDS,Random-Fields
 random-impostor training,Random-Impostor Training
 randomization,Randomization
 randomized algorithm,Randomized Algorithm
-Randomized Based Algorithm,Randomized Based Algorithm
 RANGE IMAGE SEGMENTATION,Range Image Segmentation
 rank fusion,Rank Fusion
 Rank-adaptive,Rank-Adaptive
@@ -8343,19 +6975,12 @@ RAPID HUMAN MOVEMENTS,Rapid Human Movements
 rapid movement,Rapid Movement
 Rapid prototyping,Rapid Prototyping
 RAY-FLUORESCENCE ANALYSIS,Ray-Fluorescence Analysis
-RBF,RBF
-RBF kernel,RBF kernel
-RBF kernel function,RBF kernel function
 RBF NETWORK,RBF Network
-RBF Network,RBF Network
 RBF network,RBF Network
 RBF neural network,RBF Neural Network
 RBF-NEURAL-NETWORK,RBF Neural Network
-RBM,RBM
-RCNN,RCNN
 reactive robots,Reactive Robots
 READERS,Readers
-Reading,Reading
 reading comprehension,Reading Comprehension
 READING-COMPREHENSION,Reading Comprehension
 Reading development,Reading Development
@@ -8386,8 +7011,6 @@ real-time systems,Real-Time Systems
 real-time vision processing,Real-Time Vision Processing
 reasoner,Reasoner
 reasoning,Reasoning
-Recall,Recall
-reCAPTCHA Version 2012,reCAPTCHA Version 2012
 receipt recognition,Receipt Recognition
 RECENT PROGRESS,Recent Progress
 Receptive field,Receptive Fields
@@ -8395,10 +7018,8 @@ RECEPTIVE FIELDS,Receptive Fields
 Receptive fields,Receptive Fields
 RECEPTIVE-FIELDS,Receptive-Fields
 RECOGNITION,Recognition
-Recognition,Recognition
 recognition,Recognition
 Recognition etc,Recognition
-Recognition Accuracy,Recognition Accuracy
 Recognition accuracy,Recognition Accuracy
 recognition accuracy,Recognition Accuracy
 Recognition accuracy rate,Recognition Accuracy Rate
@@ -8407,8 +7028,6 @@ recognition and interpretation,Recognition And Interpretation
 recognition and verification,Recognition And Verification
 RECOGNITION BY EXPERTS,Recognition By Experts
 recognition difficulty,Recognition Difficulty
-Recognition Domain Knowledge Kernel,Recognition Domain Knowledge Kernel
-Recognition Engine,Recognition Engine
 recognition errors,Recognition Errors
 recognition methods,Recognition Methods
 recognition OCR,Recognition OCR
@@ -8436,7 +7055,6 @@ RECOGNIZERS,Recognizers
 recognizing system,Recognizing System
 recompression operations,Recompression Operations
 reconfigurable,Reconfigurable
-Reconfigurable Hardware,Reconfigurable Hardware
 reconnaissance et indexation de donnees manuscrites et de fac similes (RIMES),Reconnaissance Et Indexation De Donnees Manuscrites Et De Fac Similes
 reconstructed image,Reconstructed Image
 RECONSTRUCTION,Reconstruction
@@ -8451,7 +7069,6 @@ recurrence plot,Recurrence Plot
 Recurrence-free model,Recurrence-Free Model
 Recurrence-free models,Recurrence-Free Models
 RECURRENT,Recurrent
-Recurrent,Recurrent
 Recurrent neural network language model,Recurrent Neural Network Language Model
 RECURRENT NETWORKS,Recurrent Neural Networks
 Recurrent networks,Recurrent Neural Networks
@@ -8463,7 +7080,6 @@ Recurrent Neural Network,Recurrent Neural Networks
 Recurrent neural network,Recurrent Neural Networks
 recurrent neural network,Recurrent Neural Networks
 recurrent neural network (RNN),Recurrent Neural Networks
-Recurrent Neural Networks,Recurrent Neural Networks
 Recurrent neural networks,Recurrent Neural Networks
 recurrent neural networks,Recurrent Neural Networks
 RECURRENT NEURAL-NETWORKS,Recurrent Neural Networks
@@ -8474,29 +7090,23 @@ redefinition of the roles of physicians and pharmacists,Redefinition Of The Role
 Reduced kernel extreme learning machine (RKELM),Reduced Kernel Extreme Learning Machine
 Reduced search strategy,Reduced Search Strategy
 REDUCTION,Reduction
-Redundancy,Redundancy
-Reevaluation,Reevaluation
 reevaluation,Reevaluation
 Reference axis,Reference Axis
 Reference line detection,Reference Line Detection
 reference lines,Reference Lines
 reflective practice,Reflective Practice
 REGEX,Regex
-Region Based Features,Region Based Features
 region classification,Region Classification
-Region Code,Region Code
 region detection,Region Detection
 Region growing segmentation,Region Growing Segmentation
 Region of attention,Region Of Attention
 region of interest,Region Of Interest
 region proposal,Region Proposal
-Region Sampling,Region Sampling
 Region sampling,Region Sampling
 region sampling,Region Sampling
 Region space,Region Space
 Regional convolutional neural network,Regional Convolutional Neural Network
 regional decomposition method,Regional Decomposition Method
-Regional Features,Regional Features
 regional projection contour transformation,Regional Projection Contour Transformation
 regions-of-interest,Regions-Of-Interest
 region-wise adaptive thresholding,Region-Wise Adaptive Thresholding
@@ -8504,19 +7114,16 @@ REGISTRATION,Registration
 registration,Registration
 REGRESSION,Regression
 regression,Regression
-Regular Expression Spotting,Regular Expression Spotting
 Regular expressions,Regular Expressions
 regular expressions,Regular Expressions
 REGULARITIES,Regularities
 REGULARITY,Regularity
 regularity measure,Regularity Measure
 REGULARIZATION,Regularization
-Regularization,Regularization
 regularization,Regularization
 regularization parameter estimation,Regularization Parameter Estimation
 regularized linear discriminant analysis,Regularized Linear Discriminant Analysis
 reinforcement learning,Reinforcement Learning
-Reject Option,Reject Option
 Reject option,Reject Option
 reject option,Reject Option
 reject procedure,Reject Procedure
@@ -8531,7 +7138,6 @@ rejection thresholds,Rejection Thresholds
 REJECT-OPTION,Reject-Option
 Relation classification,Relation Classification
 Relative neighbourhood graph,Relative Neighbourhood Graph
-Relative Position,Relative Position
 relative position,Relative Position
 RELAXATION,Relaxation
 relaxation convolution,Relaxation Convolution
@@ -8546,7 +7152,6 @@ Remote Supervised Method (ReSuMe),Remote Supervised Method
 REMOVAL,Removal
 Repetitive Strain Injuries (RSI),Repetitive Strain Injuries
 replication,Replication
-Repositioning,Repositioning
 REPRESENTATION,Representation
 Representation learning,Representation Learning
 representation learning,Representation Learning
@@ -8554,8 +7159,6 @@ REPRESENTATION OF LINE IMAGES,Representation Of Line Images
 Representation of uncertainty,Representation Of Uncertainty
 Representation transfer,Representation Transfer
 REPRESENTATIONS,Representations
-Reproducible Research,Reproducible Research
-Reproducing Kernel Hilbert Space,Reproducing Kernel Hilbert Space
 resampling,Resampling
 Re-sampling,Resampling
 rescoring,Rescoring
@@ -8565,18 +7168,15 @@ Residual attention,Residual Attention
 residual attention,Residual Attention
 residual error,Residual Error
 Residual learning,Residual Learning
-Residual Network,Residual Network
 Residual network,Residual Network
 residual network,Residual Network
 Residual network (ResNet),Residual Network
 residual networks,Residual Network
 ResNet,Residual Network
 Resnet,Residual Network
-Resilient,Resilient
 resilient backpropagation,Resilient Backpropagation
 resilient propagation,Resilient Propagation
 resistive switching behaviour,Resistive Switching Behaviour
-ResNet18,ResNet18
 Resolution enhancement,Resolution Enhancement
 RESONANCE,Resonance
 resource provisioning,Resource Provisioning
@@ -8589,19 +7189,14 @@ restricted Boltzmann machine (RBM),Restricted Boltzmann Machine
 restricted Boltzmann machines,Restricted Boltzmann Machine
 Restricted BoltzmannMachine,Restricted Boltzmann Machine
 RESULTS INTEGRATION,Results Integration
-ResU-Net,ResU-Net
 retinal progenitor cells,Retinal Progenitor Cells
 RETRIEVAL,Retrieval
-Retrieval,Retrieval
 retrieval,Retrieval
 Retrieval models,Retrieval Models
 retrieval models,Retrieval Models
-Reuters-21578,Reuters-21578
 REVEALS,Reveals
 REVISION STRATEGIES,Revision Strategies
 Reward/punishment,Reward/Punishment
-RF,RF
-RFID,RFID
 Rhetorical structure theory,Rhetorical Structure Theory
 ridgelet transform,Ridgelet Transform
 RIGHT-HANDERS,Right-Handers
@@ -8616,14 +7211,9 @@ RISK,Risk
 risk factors,Risk Factors
 river-lake,River-Lake
 RK-method,Rk-Method
-RLC,RLC
-RNN,RNN
 rnn,RNN
 RNN hybrid training algorithm,RNN Hybrid Training Algorithm
 RNN transducer,RNN Transducer
-rnnDrop,rnnDrop
-RNN-LSTM,RNN-LSTM
-Robert,Robert
 ROBOT ARM,Robot Arm
 Robot reading,Robot Reading
 Robot retrieval of document,Robot Retrieval Of Document
@@ -8642,7 +7232,6 @@ robust thinning,Robust Thinning
 robust video processing,Robust Video Processing
 Robust writer identification,Robust Writer Identification
 ROBUSTNESS,Robustness
-Robustness,Robustness
 robustness,Robustness
 robustness design,Robustness Design
 Robustness to variability,Robustness To Variability
@@ -8650,12 +7239,9 @@ ROC,Roc
 ROC curve,Roc Curves
 ROC curves,Roc Curves
 ROC front,Roc Front
-Roll,Roll
-Roman,Roman
 Roman alphanumeric,Roman Alphanumeric
 Roman script,Roman Script
 Room detection,Room Detection
-Rosetta Phone,Rosetta Phone
 rotation,Rotation
 rotation estimation,Rotation Estimation
 rotation invariant uniform local binary patterns,Rotation Invariant Uniform Local Binary Patterns
@@ -8669,32 +7255,24 @@ ROUGH SETS,Rough Sets
 Routing iteration optimization,Routing Iteration Optimization
 ROVER,Rover
 ROVER combination,Rover Combination
-Rprop,Rprop
 RULE,Rule
 rule generation,Rule Generation
 Rule inference,Rule Inference
-Rule Pruning,Rule Pruning
 rule specialization,Rule Specialization
 rule base,Rule-Base
 rule-base,Rule-Base
 Rule based system,Rule-Based System
 Rule-based system,Rule-Based System
-Ruled Lines Detection,Ruled Lines Detection
-Ruled Lines Removal,Ruled Lines Removal
 Ruled-line handwritten text recognition,Ruled-Line Handwritten Text Recognition
 Ruled-lines,Ruled-Lines
 RULES,Rules
 Ruling line detection,Ruling Line Detection
 ruling line detection,Ruling Line Detection
 Ruling line modeling,Ruling Line Modeling
-Run,Run
 Run length count,Run Length Count
 Run length smoothing alogrithm,Run Length Smoothing Alogrithm
-RU-Net,RU-Net
 run-length features,Run-Length Features
 Ruspini clustering,Ruspini Clustering
-RVC,RVC
-RWTH Arabic Handwriting Recognition System,RWTH Arabic Handwriting Recognition System
 safe screening,Safe Screening
 Sakoe-Chiba band,Sakoe-Chiba Band
 Salalom method,Salalom Method
@@ -8702,7 +7280,6 @@ salience distance transform,Salience Distance Transform
 saliency measure,Saliency Measure
 salient stroke feature extraction,Salient Stroke Feature Extraction
 sample collection,Sample Collection
-Sample Database,Sample Database
 Sample distortion,Sample Distortion
 Sample generation,Sample Generation
 Sample level,Sample Level
@@ -8713,7 +7290,6 @@ Sample separation margin,Sample Separation Margin
 sample separation margin,Sample Separation Margin
 SAMPLES,Samples
 SAMPLING METHODS,Sampling Methods
-Sankhya,Sankhya
 SAR IMAGES,Sar Images
 SASK algorithm,Sask Algorithm
 SATISFACTION,Satisfaction
@@ -8721,13 +7297,11 @@ scaffolding,Scaffolding
 scalable,Scalable
 SCALE,Scale
 scale,Scale
-Scale Invariant Feature Transform,Scale Invariant Feature Transform
 Scale Invariant Feature Transform (SIFT),Scale Invariant Feature Transform
 Scale invariant,Scale Invariants
 SCALE INVARIANTS,Scale Invariants
 scaled and warped matching,Scaled And Warped Matching
 scaled conjugate gradient,Scaled Conjugate Gradient
-Scanned Document Noise Removal,Scanned Document Noise Removal
 scanned document processing,Scanned Document Processing
 Scanned document Segmentation,Scanned Document Segmentation
 scanning data,Scanning Data
@@ -8744,51 +7318,40 @@ scene text detection,Scene Text Detection
 Scene text reading,Scene Text Reading
 Scene text recognition,Scene Text Recognition
 scene text recognition,Scene Text Recognition
-Scheduling,Scheduling
 scheduling,Scheduling
 SCHEME,Scheme
 SCHOOL,School
 SCHOOL READINESS,School Readiness
 SCHOOL-AGE-CHILDREN,School-Age-Children
-Schools,Schools
 Science mapping,Science Mapping
 SCOLEDIT dataset Study R&D project,Scoledit Dataset Study R&D Project
 SCORE NORMALIZATION,Score Normalization
 Score normalization,Score Normalization
 score-level fusion,Score-Level Fusion
 scoring psychological tests,Scoring Psychological Tests
-Scratch,Scratch
 SCREEN,Screen
 scribble-based,Scribble-Based
 scribbling,Scribbling
 SCRIPT,Script
-Script,Script
-Script Detection,Script Detection
 SCRIPT IDENTIFICATION,Script Identification
-Script Identification,Script Identification
 Script identification,Script Identification
 script identification,Script Identification
 Script identification for numerals,Script Identification For Numerals
 script independence,Script Independence
-Script Independent,Script Independent
 Script line identification,Script Line Identification
 Script normalization,Script Normalization
 Script preprocessing,Script Preprocessing
 SCRIPT RECOGNITION,Script Recognition
-Script Recognition,Script Recognition
 Script recognition,Script Recognition
 script recognition,Script Recognition
 SCRIPT RECOGNITION AND POST-PROCESSING,Script Recognition And Post-Processing
-Script Type Detection,Script Type Detection
 SCRIPTS,Scripts
-Scripts,Scripts
 scripture,Scripture
 SCUT-COUCH,Scut-Couch
 SDK,Sdk
 s-e strokes,S-E Strokes
 seal image,Seal Image
 Seal recognition,Seal Recognition
-Seam Carving,Seam Carving
 Seam carving,Seam Carving
 seam carving,Seam Carving
 SEARCH,Search
@@ -8803,7 +7366,6 @@ search/decoding algorithms,Search/Decoding Algorithms
 searchable access,Searchable Access
 Second language tutoring,Second Language Tutoring
 SECURITY,Security
-Security,Security
 security,Security
 security enhancement,Security Enhancement
 segment descriptor,Segment Descriptor
@@ -8812,7 +7374,6 @@ segment words,Segment Words
 segmental features,Segmental Features
 segmental models,Segmental Models
 SEGMENTATION,Segmentation
-Segmentation,Segmentation
 segmentation,Segmentation
 SEGMENTATION ALGORITHM,Segmentation Algorithm
 Segmentation algorithm,Segmentation Algorithm
@@ -8824,7 +7385,6 @@ segmentation error,Segmentation Error
 segmentation into strokes,Segmentation Into Strokes
 segmentation matching,Segmentation Matching
 segmentation methodologies,Segmentation Methodologies
-Segmentation Methods,Segmentation Methods
 Segmentation of cheque fields,Segmentation Of Check Fields
 Segmentation of foreground text,Segmentation Of Foreground Text
 Segmentation of Historical Arabic handwritten documents,Segmentation Of Historical Arabic Handwritten Documents
@@ -8883,7 +7443,6 @@ self-organizing,Self-Organizing
 self-organizing feature map,Self-Organizing Feature Maps
 Self-organizing feature maps,Self-Organizing Feature Maps
 SELF-ORGANIZING MAP,Self-Organizing Map
-Self-Organizing Map,Self-Organizing Map
 Self-organizing map,Self-Organizing Map
 self-organizing map,Self-Organizing Map
 self-organizing map (SOM),Self-Organizing Map
@@ -8902,11 +7461,9 @@ self-supervised adaptation,Self-Supervised Adaptation
 Self-supervised learning,Self-Supervised Learning
 self-training,Self-Training
 Semanteme embedding,Semanteme Embedding
-Semantic Analysis,Semantic Analysis
 Semantic annotation,Semantic Annotation
 semantic embedding,Semantic Embedding
 Semantic information,Semantic Information
-Semantic Knowledge Base,Semantic Knowledge Base
 semantic matching,Semantic Matching
 Semantic MediaWiki (SMW),Semantic Mediawiki
 semantic phase transition,Semantic Phase Transition
@@ -8914,8 +7471,6 @@ Semantic segmentation,Semantic Segmentation
 semantic segmentation,Semantic Segmentation
 semantic web,Semantic Web
 SEMANTICS,Semantics
-Semantics,Semantics
-SEMG,SEMG
 semi-automatic annotation,Semi-Automatic Annotation
 semi-continuous HMM,Semi-Continuous HMM
 Semi-incremental recognition,Semi-Incremental Recognition
@@ -8935,18 +7490,12 @@ Semi-Superyised Learning,Semi-Supervised Learning
 semi-supervised training,Semi-Supervised Training
 semi-tied full covariance Gaussian mixture model (STFC-GMM),Semi-Tied Full Covariance Gaussian Mixture Model
 sensing technology,Sensing Technology
-Sensitivity,Sensitivity
 SENSOR,Sensor
 SENSOR INTEROPERABILITY,Sensor Interoperability
-Sensor Pen,Sensor Pen
 Sensor systems,Sensor Systems
 SENSORS,Sensors
-Sensors,Sensors
 SENTENCE DATABASE,Sentence Database
-Separability,Separability
-Separable Convolution,Separable Convolution
 Separable Kernel Compact Support (SKCS),Separable Kernel Compact Support
-Separable MDLSTM,Separable MDLSTM
 SepMDLSTM,Separable MDLSTM
 separable multidimensional recurrent neural network,Separable Multidimensional Recurrent Neural Network
 Separate the strokes,Separate The Strokes
@@ -8955,16 +7504,13 @@ SEPARATION,Separation
 SEQUENCE,Sequence
 Sequence alignment,Sequence Alignment
 sequence bucketing,Sequence Bucketing
-Sequence Classification,Sequence Classification
 Sequence classification,Sequence Classification
 sequence classification,Sequence Classification
 sequence generation by analogy,Sequence Generation By Analogy
 Sequence labeling,Sequence Labeling
 sequence labeling,Sequence Labeling
-Sequence Learning,Sequence Learning
 sequence learning,Sequence Learning
 Sequence matching,Sequence Matching
-Sequence Models,Sequence Models
 Sequence segmentation,Sequence Segmentation
 Sequence to sequence learning,Sequence To Sequence Learning
 Seq2Seq networks,Sequence To Sequence Model
@@ -8979,27 +7525,20 @@ sequential forward search,Sequential Forward Search
 Sequential forward selection,Sequential Forward Selection
 Serial combination,Serial Combination
 serial combination,Serial Combination
-Servers,Servers
 SE-seglink method,Se-Seglink Method
 SET,Set
 SET RECOGNITION,Set Recognition
 SEX,Sex
 SEX-DIFFERENCES,Sex-Differences
-SFAM,SFAM
-SGD optimizer,SGD optimizer
-SGML,SGML
-Shadow Features,Shadow Features
 Shallow language model,Shallow Language Model
 Shallow networks,Shallow Networks
 Shannon entropy,Shannon Entropy
 SHAPE,Shape
-Shape,Shape
 shape,Shape
 SHAPE ANALYSIS,Shape Analysis
 shape analysis,Shape Analysis
 Shape based feature,Shape Based Feature
 Shape codebook,Shape Codebook
-Shape Complexity,Shape Complexity
 Shape context descriptor,Shape Context Descriptor
 Shape conttal descriptor,Shape Context Descriptor
 shape context,Shape Contexts
@@ -9036,10 +7575,8 @@ SHAPES,Shapes
 shapley value,Shapley Value
 shared weight networks,Shared Weight Networks
 Shared weights,Shared Weights
-Sharpening,Sharpening
 SHIFT,Shift
 SHIFTS,Shifts
-Shirorekha,Shirorekha
 short answer assessment,Short Answer Assessment
 shortcut connection,Shortcut Connection
 shortest path algorithms,Shortest Path Algorithms
@@ -9048,16 +7585,13 @@ short-term memory neural networks,Short-Term Memory Neural Networks
 short-time energy,Short-Time Energy
 Show-through,Show-Through
 SHRINKAGE-THRESHOLDING ALGORITHM,Shrinkage-Thresholding Algorithm
-SHROUT,SHROUT
 Siamese Network,Siamese Neural Network
 Siamese network,Siamese Neural Network
 Siamese networks,Siamese Neural Network
 Siamese neural network,Siamese Neural Network
-SIFT,SIFT
 SIFT decriptor,SIFT Descriptor
 SIFT descriptor,SIFT Descriptor
 sigma feature of handwriting recognition,Sigma Feature Of Handwriting Recognition
-Sigma-Lognormal,Sigma-Lognormal
 Sigma-Lognormal model,Sigma-Lognormal Model
 Sigma-lognormal model,Sigma-Lognormal Model
 SIGNAL AND IMAGE CLASSIFICATION,Signal And Image Classification
@@ -9068,7 +7602,6 @@ SIGNAL-PROCESSING ALGORITHMS,Signal-Processing Algorithms
 SIGNALS,Signals
 SIGNALS ANALYSIS,Signals Analysis
 SIGNATURE,Signature
-Signature,Signature
 signature,Signature
 Signature authentication,Signature Authentication
 signature biometrics,Signature Biometrics
@@ -9076,23 +7609,17 @@ signature complexity,Signature Complexity
 signature datasets,Signature Datasets
 Signature detection,Signature Detection
 Signature detection evasion,Signature Detection Evasion
-Signature Envelope,Signature Envelope
 signature examination,Signature Examination
 Signature forgery detection,Signature Forgery Detection
-Signature Identification,Signature Identification
 Signature identification,Signature Identification
-Signature Recognition,Signature Recognition
 Signature recognition,Signature Recognition
 signature recognition,Signature Recognition
 Signature representation,Signature Representation
-Signature Segmentation,Signature Segmentation
 Signature segmentation,Signature Segmentation
-Signature Spotting,Signature Spotting
 Signature stability,Signature Stability
 Signature synthesis,Signature Synthesis
 signature template security,Signature Template Security
 SIGNATURE VERIFICATION,Signature Verification
-Signature Verification,Signature Verification
 Signature verification,Signature Verification
 signature verification,Signature Verification
 Signatures verification,Signature Verification
@@ -9105,7 +7632,6 @@ Significant position encoding,Significant Position Encoding
 SIGN-LANGUAGE RECOGNITION,Sign-Language Recognition
 silicon photonics,Silicon Photonics
 similar character group,Similar Character Group
-Similar Character Recognition,Similar Character Recognition
 Similar characters,Similar Characters
 similar characters,Similar Characters
 similar characters discrimination,Similar Characters Discrimination
@@ -9114,18 +7640,14 @@ Similar handwritten Chinese character recognition,Similar Handwritten Chinese Ch
 similar segmented characters,Similar Segmented Characters
 Similar shaped character recognition,Similar Shaped Character Recognition
 SIMILARITY,Similarity
-Similarity,Similarity
 similarity,Similarity
 similarity correlation,Similarity Correlation
 similarity detection,Similarity Detection
 similarity distance,Similarity Distance
-Similarity Index,Similarity Index
 Similarity learning,Similarity Learning
 similarity learning,Similarity Learning
-Similarity Measure,Similarity Measure
 similarity measure,Similarity Measure
 similarity preservation,Similarity Preservation
-Similarity Ranking,Similarity Ranking
 Similarity recognition,Similarity Recognition
 similarity retrieval,Similarity Retrieval
 similarity score fusion,Similarity Score Fusion
@@ -9141,8 +7663,6 @@ simplified SVM,Simplified SVM
 SIMULATED ANNEALING,Simulated Annealing
 simulated light sensitive model,Simulated Light Sensitive Model
 SIMULATION,Simulation
-Simulink HDL coder,Simulink HDL coder
-Sindhi,Sindhi
 Sindhi digit Recogniation,Sindhi Digit Recogniation
 Sindhi handwriten-digits,Sindhi Handwriten-Digits
 Sindhi script,Sindhi Script
@@ -9152,19 +7672,13 @@ single character level,Single Character Level
 single partition testing,Single Partition Testing
 Single scale retinex,Single Scale Retinex
 Single stroke characters,Single Stroke Characters
-Single Word Recognition,Single Word Recognition
 single-script offline databases,Single-Script Offline Databases
 Single-stroke classification,Single-Stroke Classification
 Single-subject design,Single-Subject Design
 Single-touching strings,Single-Touching Strings
-Singlish Transliteration,Singlish Transliteration
 Singular value decomposition,Singular Value Decomposition
 SINGULARITIES,Singularities
-Sinhala,Sinhala
 Sinhala and English Bilingual Translator,Sinhala And English Bilingual Translator
-Sinhala Handwriting Recognition,Sinhala Handwriting Recognition
-Sinhala Handwritten Character Recognition,Sinhala Handwritten Character Recognition
-Sinhala OCR,Sinhala OCR
 sinusitis,Sinusitis
 Sinusoidal features,Sinusoidal Features
 Sinusoidal model,Sinusoidal Model
@@ -9173,23 +7687,18 @@ Sixteen-value transformation,Sixteen-Value Transformation
 SIZE,Size
 SIZE INVARIANCE,Size Invariance
 SIZE NORMALIZATION,Size Normalization
-Skeletionisation,Skeletionisation
 skeleton,Skeleton
 skeleton analysis,Skeleton Analysis
 skeleton coding,Skeleton Coding
 skeleton decomposition,Skeleton Decomposition
-Skeleton Directional Decomposition,Skeleton Directional Decomposition
 SKELETON GRAPHS,Skeleton Graphs
 Skeleton hinge distribution,Skeleton Hinge Distribution
 skeleton orientation,Skeleton Orientation
 skeleton tracing,Skeleton Tracing
 skeletonisation,Skeletonization
 SKELETONIZATION,Skeletonization
-Skeletonization,Skeletonization
 skeletonization,Skeletonization
-Sketch,Sketch
 sketch,Sketch
-Sketch Grouping,Sketch Grouping
 Sketch recognition,Sketch Recognition
 sketch recognition,Sketch Recognition
 sketch-based interface,Sketch-Based Interface
@@ -9197,9 +7706,7 @@ SKETCH-BASED INTERFACES,Sketch-Based Interfaces
 sketching,Sketching
 Sketching order,Sketching Order
 Sketching recognition,Sketching Recognition
-SketchML,SketchML
 SKEW,Skew
-Skew,Skew
 skew,Skew
 skew angle estimation,Skew Angle Estimation
 Skew correction,Skew Correction
@@ -9213,8 +7720,6 @@ Skewed line segmentation,Skewed Line Segmentation
 skewness,Skewness
 SKILL,Skill
 SKILLS,Skills
-Skip Architecture,Skip Architecture
-Slab,Slab
 slalom method,Slalom Method
 slant and tilt correction,Slant And Tilt Correction
 SLANT CORRECTION,Slant Correction
@@ -9227,50 +7732,32 @@ Slant removal and skew correction,Slant Removal And Skew Correction
 slantlet,Slantlet
 Slantlet coefficients,Slantlet Coefficients
 SLANTLET TRANSFORM,Slantlet Transform
-Slavic,Slavic
-Slavonic,Slavonic
 SLEEP,Sleep
 Sliding window,Sliding Window
 sliding window,Sliding Window
-Sliding Window Amplitude Feature,Sliding Window Amplitude Feature
 Sliding Window technique,Sliding Window Technique
 slope correction,Slope Correction
 sloppy handwriting,Sloppy Handwriting
-SLR,SLR
-Small Eigen Values,Small Eigen Values
 small sketch recognition,Small Sketch Recognition
 small-sized vocabularies,Small-Sized Vocabularies
 Small-step semantics,Small-Step Semantics
 smart electronics,Smart Electronics
-Smart Factory,Smart Factory
 Smart factory,Smart Factory
 Smart glasses,Smart Glasses
 smart grid,Smart Grid
 Smart homes,Smart Homes
-Smart Pen,Smart Pen
 Smart phones,Smart Phones
 smart vision systems,Smart Vision Systems
 Smartphone Arabic document capture database,Smartphone Arabic Document Capture Database
-Smartwatch,Smartwatch
 Smearing technique,Smearing Technique
 Smirnov test,Smirnov Test
-SMO ALGORITHM,SMO ALGORITHM
-SMO classifier,SMO classifier
 Smoothening,Smoothing
-Smoothing,Smoothing
 smoothing,Smoothing
-Smoothing Algorithms,Smoothing Algorithms
 Smoothing methods,Smoothing Methods
 smoothing methods,Smoothing Methods
-SMQDF classifier,SMQDF classifier
-SNN,SNN
-SOA,SOA
-Sobel,Sobel
-Sobel Filter,Sobel Filter
 Sobel filter,Sobel Filter
 social media,Social Media
 Social networking (online),Social Networking (Online)
-Social Robot,Social Robot
 socially accepted biometric traits,Socially Accepted Biometric Traits
 SOFT,Soft
 SOFT BIOMETRICS,Soft Biometrics
@@ -9289,28 +7776,21 @@ Softmax regression model,Softmax Regression Model
 SOFTWARE,Software
 software algorithms,Software Algorithms
 Software architecture,Software Architecture
-Software Categories,Software Categories
 Software categories,Software Categories
 software engineering,Software Engineering
 software framework,Software Framework
 software keyboard,Software Keyboard
 Software product line engineering,Software Product Line Engineering
-SOINN,SOINN
 solutions,Solutions
 solvent-free,Solvent-Free
-SOM,SOM
 SORTING ALGORITHM,Sorting Algorithm
 sorting filter,Sorting Filter
 sound emissions,Sound Emissions
 Sound localization,Sound Localization
-South Indian Languages,South Indian Languages
 South Indian languages,South Indian Languages
 SPACE,Space
 space modeling,Space Modeling
-Space-Time Analysis,Space-Time Analysis
-Space-Time Kernels,Space-Time Kernels
 SPAM,Spam
-Spam,Spam
 Spanish resources,Spanish Resources
 spanning ratio,Spanning Ratio
 SPARSE,Sparse
@@ -9326,13 +7806,10 @@ sparse coding,Sparse Coding
 sparse distributed memory,Sparse Distributed Memory
 Sparse learning,Sparse Learning
 Sparse projection,Sparse Projection
-Sparse Representation,Sparse Representation
 Sparse representation,Sparse Representation
 sparse representation,Sparse Representation
-Sparse Representation Classifier,Sparse Representation Classifier
 sparse representation-based features,Sparse Representation-Based Features
 SPARSELY CONNECTED NEURAL NETWORKS,Sparsely Connected Neural Networks
-Sparsity,Sparsity
 sparsity,Sparsity
 spatial data structures,Spatial Data Structures
 spatial domain,Spatial Domain
@@ -9341,10 +7818,8 @@ spatial feature modelling,Spatial Feature Modelling
 SPATIAL LANGUAGE,Spatial Language
 spatial matched filtering,Spatial Matched Filtering
 Spatial pattern recognition,Spatial Pattern Recognition
-Spatial Pyramid Pooling,Spatial Pyramid Pooling
 spatial relation,Spatial Relations
 SPATIAL RELATIONS,Spatial Relations
-Spatial Relations,Spatial Relations
 Spatial relations,Spatial Relations
 spatial relations,Spatial Relations
 Spatial Relationships,Spatial Relations
@@ -9367,7 +7842,6 @@ SPEAKER ADAPTATION,Speaker Adaptation
 SPEAKER RECOGNITION,Speaker Recognition
 speaker recognition,Speaker Recognition
 SPEAKER VERIFICATION,Speaker Verification
-Specificity,Specificity
 Spectral analysis,Spectral Analysis
 Spectral clustering,Spectral Clustering
 spectral hashing,Spectral Hashing
@@ -9375,44 +7849,36 @@ SPECTRAL KURTOSIS,Spectral Kurtosis
 spectral regression discriminant analysis,Spectral Regression Discriminant Analysis
 Spectrogram images,Spectrogram Images
 spectroscopy,Spectroscopy
-Spectrum Diagram,Spectrum Diagram
 SPECULATIVE ADDITION,Speculative Addition
 SPEECH,Speech
 speech,Speech
 Speech and handwriting patterns,Speech And Handwriting Patterns
 Speech dictation,Speech Dictation
 SPEECH ENHANCEMENT,Speech Enhancement
-Speech Enhancement,Speech Enhancement
 SPEECH RECOGNITION,Speech Recognition
-Speech Recognition,Speech Recognition
 Speech recognition,Speech Recognition
 speech recognition,Speech Recognition
 SPEECH SYNTHESIS,Speech Synthesis
 Speech synthesis,Speech Synthesis
 SPEED,Speed
-Speeded Up Robust Feature,Speeded Up Robust Feature
 Speeded up robust features,Speeded Up Robust Features
 speedup,Speedup
 Speedup Robust Feature (SURF),Speedup Robust Feature
 SPELLING,Spelling
-Spelling,Spelling
 spelling,Spelling
 SPELLING ABILITY,Spelling Ability
 spelling correction,Spelling Correction
 SPELLING ERROR CORRECTION,Spelling Error Correction
 spelling error correction,Spelling Error Correction
 SPELLING INSTRUCTION,Spelling Instruction
-Spelling Test,Spelling Test
 spiking neural network,Spiking Neural Network
 Spiking Neural Network (SNN),Spiking Neural Network
 spiking neural network (SNN),Spiking Neural Network
 spiking neural networks,Spiking Neural Network
 spiking neurons,Spiking Neurons
-Spintronics,Spintronics
 spintronics,Spintronics
 SPIRAL ANALYSIS,Spiral Analysis
 spiral recognition methodology,Spiral Recognition Methodology
-Spirals,Spirals
 splicing module,Splicing Module
 Spline curve,Spline Curve
 Spline function,Spline Function
@@ -9420,17 +7886,12 @@ spline function,Spline Function
 spline interpolation,Spline Interpolation
 Spoken document retrieval,Spoken Document Retrieval
 spotting,Spotting
-Spreadsheet,Spreadsheet
 SqueezeNet,Squeezenet
-SRC,SRC
 STABILITY,Stability
-Stability,Stability
-Stability Analysis,Stability Analysis
 Stability analysis,Stability Analysis
 stability of a dynamic biometric signature,Stability Of A Dynamic Biometric Signature
 stability of dynamic biometric signature,Stability Of Dynamic Biometric Signature
 Stable equilibria,Stable Equilibria
-Stacked Auto Encoder,Stacked Auto Encoder
 stacked Autoencoder,Stacked Auto Encoder
 STACKED GENERALIZATION,Stacked Generalization
 Stacked generalization,Stacked Generalization
@@ -9450,21 +7911,17 @@ state tying,State Tying
 state-based clustering,State-Based Clustering
 OF-THE-ART,state-of-the-art
 State-of-the-art,state-of-the-art
-state-of-the-art,state-of-the-art
 THE-ART,state-of-the-art
 state-of-the-art methods,State-Of-The-Art Methods
 State-transition probabilities,State-Transition Probabilities
 state-tying based on structural similarity,State-Tying Based On Structural Similarity
 Static and adaptive,Static And Adaptive
 static and dynamic representation,Static And Dynamic Representation
-Static Authentication,Static Authentication
 Static candidates generation,Static Candidates Generation
 static handwritten signature,Static Handwritten Signature
 Static lexicon,Static Lexicon
 static line image,Static Line Image
-Static Signature,Static Signature
 STATIC SIGNATURES,Static Signature
-Statistical,Statistical
 Statistical analysis,Statistical Analysis
 statistical analysis,Statistical Analysis
 Statistical and contour-based features (SCF),Statistical And Contour-Based Features
@@ -9480,13 +7937,10 @@ statistical classifiers,Statistical Classifiers
 statistical evaluation,Statistical Evaluation
 statistical feature extraction,Statistical Feature Extraction
 Statistical Feature,Statistical Features
-Statistical Features,Statistical Features
 statistical features,Statistical Features
-Statistical Filters,Statistical Filters
 statistical filters,Statistical Filters
 statistical geometric components,Statistical Geometric Components
 statistical handwriting recognition,Statistical Handwriting Recognition
-Statistical Inference,Statistical Inference
 statistical language,Statistical Language
 Statistical language model,Statistical Language Model
 statistical language model,Statistical Language Model
@@ -9508,9 +7962,7 @@ statistical recognition,Statistical Recognition
 statistical texture analysis,Statistical Texture Analysis
 STATISTICS,Statistics
 statistics,Statistics
-Steel,Steel
 steel box girder,Steel Box Girder
-Steel Company,Steel Company
 steepest descent,Steepest Descent
 Steerable pyramid transform,Steerable Pyramid Transform
 steerable pyramids,Steerable Pyramids
@@ -9522,7 +7974,6 @@ stochastic approach,Stochastic Approach
 stochastic computing,Stochastic Computing
 stochastic edit distance,Stochastic Edit Distance
 stochastic finite-state transducers,Stochastic Finite-State Transducers
-Stochastic Gradient Descent,Stochastic Gradient Descent
 stochastic gradient search,Stochastic Gradient Search
 stochastic model of letter,Stochastic Model Of Letter
 Stochastic optimization,Stochastic Optimization
@@ -9534,7 +7985,6 @@ stockwell,Stockwell
 stone inscriptions,Stone Inscriptions
 STORAGE CAPACITY,Storage Capacity
 stored samples,Stored Samples
-Storkey,Storkey
 straight lines,Straight Lines
 STRAIN,Strain
 strain,Strain
@@ -9547,7 +7997,6 @@ Stream processing,Stream Processing
 Streaming SIMD Extensions,Streaming Simd Extensions
 streaming videos,Streaming Videos
 Street name recognition,Street Name Recognition
-Stress,Stress
 stress,Stress
 stretch sensor,Stretch Sensor
 STRETCHABLE ELECTRONICS,Stretchable Electronics
@@ -9569,10 +8018,8 @@ STRINGS,Strings
 Strip based projection profile,Strip Based Projection Profile
 Strip tree,Strip Tree
 STROKE,Stroke
-Stroke,Stroke
 stroke,Stroke
 Stroke (medical condition),Stroke (Medical Condition)
-Stroke Based Features,Stroke Based Features
 Stroke character representation,Stroke Character Representation
 stroke character representation,Stroke Character Representation
 STROKE CLASSIFICATION,Stroke Classification
@@ -9595,7 +8042,6 @@ STROKE FEATURES,Stroke Features
 stroke gestures,Stroke Gestures
 Stroke grouping,Stroke Grouping
 stroke grouping,Stroke Grouping
-Stroke Identification,Stroke Identification
 stroke identification,Stroke Identification
 Stroke level,Stroke Level
 Stroke measurement,Stroke Measurement
@@ -9607,7 +8053,6 @@ stroke path detection,Stroke Path Detection
 stroke phenomena,Stroke Phenomena
 stroke primitives,Stroke Primitives
 stroke production,Stroke Production
-Stroke Recognition,Stroke Recognition
 stroke reconstruction,Stroke Reconstruction
 Stroke recovery,Stroke Recovery
 stroke recovery,Stroke Recovery
@@ -9623,16 +8068,13 @@ STROKE SIZE,Stroke Size
 stroke spatial relationship error,Stroke Spatial Relationship Error
 stroke structure,Stroke Structure
 stroke traversal,Stroke Traversal
-Stroke Warping,Stroke Warping
 stroke width,Stroke Width
-Stroke Width Transform,Stroke Width Transform
 Stroke-based busy-zone,Stroke-Based Busy-Zone
 Stroke-based matched vector graph,Stroke-Based Matched Vector Graph
 Stroke-based vector graph,Stroke-Based Vector Graph
 STROKE-EXTRACTION,Stroke-Extraction
 stroke-order normalization,Stroke-Order Normalization
 STROKES,Strokes
-Strokes,Strokes
 strokes,Strokes
 strokes association,Strokes Association
 Strokes classification,Strokes Classification
@@ -9654,13 +8096,10 @@ structural components,Structural Components
 structural decomposition,Structural Decomposition
 STRUCTURAL DESCRIPTION,Structural Description
 structural description,Structural Description
-Structural Feature,Structural Feature
 structural feature,Structural Feature
-Structural Features,Structural Features
 Structural features,Structural Features
 structural features,Structural Features
 structural features combination,Structural Features Combination
-Structural Features Extraction,Structural Features Extraction
 structural information,Structural Information
 STRUCTURAL MATCHING,Structural Matching
 structural matching,Structural Matching
@@ -9673,7 +8112,6 @@ Structural operational semantics,Structural Operational Semantics
 structural parameters,Structural Parameters
 Structural pattern analysis,Structural Pattern Analysis
 STRUCTURAL PATTERN RECOGNITION,Structural Pattern Recognition
-Structural Pattern Recognition,Structural Pattern Recognition
 Structural pattern recognition,Structural Pattern Recognition
 structural pattern recognition,Structural Pattern Recognition
 structural primitives,Structural Primitives
@@ -9689,13 +8127,11 @@ structure algorithms,Structure Algorithms
 Structure analysis,Structure Analysis
 structure extraction,Structure Extraction
 structure identification,Structure Identification
-Structure Learning,Structure Learning
 Structure learning,Structure Learning
 structured case,Structured Case
 structured document recognition,Structured Document Recognition
 Structured learning,Structured Learning
 Student identification and verification system,Student Identification And Verification System
-Student Identification System,Student Identification System
 student identification system,Student Identification System
 student teachers,Student Teachers
 STUDENTS,Students
@@ -9712,10 +8148,7 @@ stylometry,Stylometry
 stylus,Stylus
 stylus input,Stylus Input
 Sub stroke Extraction and analysis,Sub Stroke Extraction And Analysis
-Sub-character HMM,Sub-character HMM
-Sub-character HMMs,Sub-character HMMs
 subcharacter models,Sub-character Models
-Subclass Low Variances,Subclass Low Variances
 subclass method,Subclass Method
 Sub-component features,Sub-Component Features
 Subcortical lesion,Subcortical Lesion
@@ -9726,7 +8159,6 @@ subjective error analysis,Subjective Error Analysis
 Sub-lexical units,Sub-Lexical Units
 Submodular optimization,Submodular Optimization
 subnetworks,Subnetworks
-Sub-Saharan Africa,Sub-Saharan Africa
 subsequence matching,Subsequence Matching
 Subset selection,Subset Selection
 SUBSPACE,Subspace
@@ -9736,12 +8168,10 @@ subspace learning,Subspace Learning
 Subspace method,Subspace Method
 SUBSPACE SEGMENTATION,Subspace Segmentation
 SUBSPACES,Subspaces
-Subspaces,Subspaces
 SUBSTANTIA-NIGRA,Substantia-Nigra
 substitution error,Substitution Error
 sub-stroke based feature vectors,Sub-Stroke Based Feature Vectors
 substructure,Substructure
-Sub-Structure Learning,Sub-Structure Learning
 substructure recognition,Substructure Recognition
 sub-vector matching,Sub-Vector Matching
 subword,Subword
@@ -9750,18 +8180,14 @@ successor attribute matrix,Successor Attribute Matrix
 successor method,Successor Method
 Sugeno integral,Sugeno Integral
 Sugeno measures,Sugeno Measures
-Sugeno's Fuzzy Integral,Sugeno's Fuzzy Integral
 suggested method,Suggested Method
-Suicidal Intention,Suicidal Intention
 sum combination,Sum Combination
 sum-pooled sparse coefficients,Sum-Pooled Sparse Coefficients
 sum-product algorithm,Sum-Product Algorithm
 Sunspot drawings,Sunspot Drawings
 supercomputing,Supercomputing
 SUPERIOR PARIETAL CORTEX,Superior Parietal Cortex
-Superpixel,Superpixel
 SUPERRESOLUTION,Super-Resolution
-Super-Resolution,Super-Resolution
 supervised adaptation,Supervised Adaptation
 Supervised classification based segmentation,Supervised Classification Based Segmentation
 Supervised learning,Supervised Learning
@@ -9771,7 +8197,6 @@ supervised training,Supervised Training
 SUPPORT,Support
 Support tensor machines,Support Tensor Machines
 SUPPORT VECTOR MACHINE,Support Vector Machine
-Support Vector Machine,Support Vector Machine
 Support vector machine,Support Vector Machine
 support vector machine,Support Vector Machine
 Support Vector Machine (SVM),Support Vector Machine
@@ -9785,7 +8210,6 @@ support vector machines (SVM),Support Vector Machine
 support vector machines (SVMs),Support Vector Machine
 Support-vector machines,Support Vector Machines
 support vector machines complementarity,Support Vector Machines Complementarity
-Support Vector Regression,Support Vector Regression
 Support Vector System (SVM),Support Vector System
 SUPPRESSION,Suppression
 SURF,Surf
@@ -9796,7 +8220,6 @@ Surface electromyography (sEMG),Surface Electromyography (Semg)
 SURFACE INSPECTION,Surface Inspection
 SURGERY,Surgery
 surveillance camera,Surveillance Camera
-Survey,Survey
 survey,Survey
 surveyed articles,Surveyed Articles
 surveys,Surveys
@@ -9804,27 +8227,21 @@ SURVIVAL ANALYSIS,Survival Analysis
 survival course,Survival Course
 SUSAN,Susan
 suspect investigation,Suspect Investigation
-SVM,SVM
 svm,SVM
 SVMS,SVM
 SVMs,SVM
 SVM classification,SVM Classification
-SVM Classifier,SVM Classifier
 SVM classifier,SVM Classifier
 SVM re-scoring,SVM Re-Scoring
 SVM based classification,SVM-Based Classification
 switch plan,Switch Plan
 syllable assignment,Syllable Assignment
 SYLLABLES,Syllables
-Syllables,Syllables
-Symbol Annotation,Symbol Annotation
 symbol beautification,Symbol Beautification
-Symbol Classification,Symbol Classification
 symbol classification,Symbol Classification
 symbol level annotation,Symbol Level Annotation
 symbol order variation,Symbol Order Variation
 SYMBOL RECOGNITION,Symbol Recognition
-Symbol Recognition,Symbol Recognition
 Symbol recognition,Symbol Recognition
 symbol recognition,Symbol Recognition
 SYMBOL SEGMENTATION,Symbol Segmentation
@@ -9835,9 +8252,7 @@ SYMBOLIC DESCRIPTION,Symbolic Description
 symbolic indirect correlation,Symbolic Indirect Correlation
 symbolic learning,Symbolic Learning
 SYMBOLIC REPRESENTATION,Symbolic Representation
-Symbolism,Symbolism
 SYMBOLS,Symbols
-Symbols,Symbols
 symmetric uncertainty,Symmetric Uncertainty
 SymmetricChord,Symmetricchord
 SYNAPSE,Synapses
@@ -9847,62 +8262,48 @@ SYNTACTIC ANALYSIS,Syntactic Analysis
 syntactic analysis,Syntactic Analysis
 SYNTACTIC APPROACH,Syntactic Approach
 Syntactic data generation,Syntactic Data Generation
-Syntactic Pattern Recognition,Syntactic Pattern Recognition
 Syntactic pattern recognition,Syntactic Pattern Recognition
 syntactic pattern recognition,Syntactic Pattern Recognition
-Syntax Analysis (Parsing),Syntax Analysis (Parsing)
 synthesis,Synthesis
-Synthetic,Synthetic
 Synthetic character database,Synthetic Character Database
 Synthetic data,Synthetic Data
 synthetic data,Synthetic Data
-Synthetic Data Generation,Synthetic Data Generation
 Synthetic dataset,Synthetic Dataset
 synthetic dataset,Synthetic Dataset
 Synthetic generation,Synthetic Generation
 synthetic generation,Synthetic Generation
 Synthetic handwriting,Synthetic Handwriting
 Synthetic image,Synthetic Image
-Synthetic Image Generation,Synthetic Image Generation
 Synthetic number database,Synthetic Number Database
 synthetic offline signatures,Synthetic Offline Signatures
 synthetic training data,Synthetic Training Data
 Synthetic training data generation,Synthetic Training Data Generation
 Synthetic training samples,Synthetic Training Samples
-Synthetic Variations,Synthetic Variations
 SYSTEM,System
-System Combination,System Combination
 system combination,System Combination
 system design,System Design
 System evaluation,System Evaluation
 system integration,System Integration
 System security,System Security
-Systematics,Systematics
 SYSTEMS,Systems
 systems,Systems
 systems and applications,Systems And Applications
 Systems evaluation,Systems Evaluation
-Systems for PR,Systems for PR
 table,Table
 tables,Table
 TABLE DETECTION,Table Detection
 table detection,Table Detection
 table matching,Table Matching
 table recognition,Table Recognition
-Tablet,Tablet
 Tablets,Tablet
 TABLET DIGITIZERS,Tablet Digitizers
-Tablet PC,Tablet PC
 tabular document images,Tabular Document Images
 tachycardia,Tachycardia
 tactile tablets,Tactile Tablets
 Tai Le recognition,Tai Le Recognition
 tail-removal,Tail-Removal
 TAKE-ALL CIRCUIT,Take-All Circuit
-Tally,Tally
-TALN,TALN
 TAMIL,Tamil
-Tamil,Tamil
 Tamil character recognition,Tamil Character Recognition
 Tamil handwriting recognition,Tamil Handwriting Recognition
 Tamil handwritten character database,Tamil Handwritten Character Database
@@ -9928,8 +8329,6 @@ taxonomy,Taxonomy
 Taylor series,Taylor Series
 Tchebichef moments,Tchebichef Moments
 tchebichef moments,Tchebichef Moments
-TCN,TCN
-TDNN,TDNN
 teacher education curriculum,Teacher Education Curriculum
 TEACHERS,Teachers
 Teaching-learning-based optimization algorithm,Teaching-Learning-Based Optimization Algorithm
@@ -9939,20 +8338,15 @@ TECHNICAL DRAWINGS,Technical Drawings
 TECHNICAL FEATURES,Technical Features
 TECHNOLOGIES,Technology
 TECHNOLOGY,Technology
-Technology,Technology
 technology assessment,Technology Assessment
 teenagers,Teenagers
 telecommunication computing,Telecommunication Computing
 TELEFORM,Teleform
-Telegeriatrics,Telegeriatrics
-Telugu,Telugu
 Telugu language,Telugu Language
 Telugu strokes,Telugu Strokes
 TEMPLATE,Template
-Template,Template
 template,Template
 template ageing effect,Template Ageing Effect
-Template Based Forms,Template Based Forms
 Template classification,Template Classification
 template constrained posterior (TCP),Template Constrained Posterior
 template images,Template Images
@@ -9971,7 +8365,6 @@ temporal dependences modeling,Temporal Dependences Modeling
 TEMPORAL INFORMATION,Temporal Information
 temporal information,Temporal Information
 Temporal order recovery,Temporal Order Recovery
-Temporal Pattern Recognition,Temporal Pattern Recognition
 temporal pattern recognition,Temporal Pattern Recognition
 TEMPORAL PATTERNS,Temporal Patterns
 temporal prediction,Temporal Prediction
@@ -9983,38 +8376,26 @@ tensor decompositions,Tensor Decompositions
 tensor networks,Tensor Networks
 tensor-based subspace learning,Tensor-Based Subspace Learning
 tensor flow,TensorFlow
-TensorFlow,TensorFlow
 Tensorflow,TensorFlow
 tensorflow,TensorFlow
-Tensors,Tensors
 term rewriting system,Term Rewriting System
 term-frequency inversed document,Term-Frequency Inversed Document
 terminology,Terminology
 ternary entropy-based,Ternary Entropy-Based
-Tesseract,Tesseract
 test collections,Test Collections
 test sample,Test Sample
 TESTING,Testing
-Testing,Testing
-Testing Hypothesis,Testing Hypothesis
 testing support vector machine classifier,Testing Support Vector Machine Classifier
 TEXT,Text
-TexT,TexT
-Text,Text
 text,Text
-Text Analysis,Text Analysis
 Text analysis,Text Analysis
 text analysis,Text Analysis
 Text and symbol recognition,Text And Symbol Recognition
-Text Auto-Completion,Text Auto-Completion
-Text Categorization,Text Categorization
 Text categorization,Text Categorization
 text categorization,Text Categorization
 Text composition,Text Composition
 text composition,Text Composition
-Text Content Based Features,Text Content Based Features
 TEXT DETECTION,Text Detection
-Text Detection,Text Detection
 Text detection,Text Detection
 text detection,Text Detection
 Text digitization,Text Digitization
@@ -10033,7 +8414,6 @@ text image datasets,Text Image Datasets
 Text image normalization,Text Image Normalization
 TEXT IMAGES,Text Images
 TIE (Text Information Extraction),Text Information Extraction
-Text Input,Text Input
 text input,Text Input
 TEXT LINE,Text Line
 Text line,Text Line
@@ -10052,13 +8432,11 @@ TEXT PROCESSING,Text Processing
 TEXT PRODUCTION,Text Production
 Text quality,Text Quality
 TEXT RECOGNITION,Text Recognition
-Text Recognition,Text Recognition
 Text recognition,Text Recognition
 text recognition,Text Recognition
 text region detection and classification,Text Region Detection And Classification
 text retrieval,Text Retrieval
 TEXT SEGMENTATION,Text Segmentation
-Text Segmentation,Text Segmentation
 Text segmentation,Text Segmentation
 text segmentation,Text Segmentation
 Text separation,Text Separation
@@ -10109,7 +8487,6 @@ TTS (Text-to-speech),Text-To-Speech
 Textual domain,Textual Domain
 textual domain,Textual Domain
 textural descriptors,Textural Descriptors
-Textural Features,Textural Features
 TEXTURE,Texture
 texture,Texture
 Texture analysis,Texture Analysis
@@ -10117,17 +8494,13 @@ texture analysis,Texture Analysis
 texture Analysis technique,Texture Analysis Technique
 Texture based feature,Texture Based Feature
 TEXTURE CLASSIFICATION,Texture Classification
-Texture Descriptor,Texture Descriptor
 Texture descriptors,Texture Descriptors
 TEXTURE-DISCRIMINATION,Texture Discrimination
 Texture features,Texture Features
 the texture level,Texture Level
-Texture Measurement,Texture Measurement
 TEXTURE SEGMENTATION,Texture Segmentation
-Thai Character Recognition,Thai Character Recognition
 Thai character recognition,Thai Character Recognition
 Thai handwriting recognition,Thai Handwriting Recognition
-Thai Handwritten Character,Thai Handwritten Character
 Thai handwritten character recognition,Thai Handwritten Character Recognition
 Thai name components,Thai Name Components
 Thai signature and name component recognition and verification,Thai Signature And Name Component Recognition And Verification
@@ -10138,57 +8511,45 @@ THEORY,Theory
 Thin plate spline transformation,Thin Plate Spline Transformation
 THINGS,Things
 THINNING,Thinning
-Thinning,Thinning
 thinning,Thinning
 THINNING ALGORITHM,Thinning Algorithm
-Thinning Algorithm,Thinning Algorithm
 Thinning algorithm,Thinning Algorithm
 thinning algorithm,Thinning Algorithm
 THINNING ALGORITHMS,Thinning Algorithm
 thinning algorithms,Thinning Algorithm
 THINNING DIGITAL PATTERNS,Thinning Digital Patterns
-Thmande Bayesian Network,Thmande Bayesian Network
 Thomas algorithm,Thomas Algorithm
 Three-color bar character encoding,Three-Color Bar Character Encoding
 Three-terminal MTJ,Three-Terminal MTJ
 threshold entropy,Threshold Entropy
 threshold model,Threshold Model
 THRESHOLD SELECTION METHOD,Threshold Selection Method
-Thresholding,Thresholding
 thresholding,Thresholding
 thresholds,Thresholds
 Tibetan characters,Tibetan Characters
 Tibetan Transliteration of the Sanskrit,Tibetan Transliteration Of The Sanskrit
-Tibeto-Burman,Tibeto-Burman
 Tifinagh handwritten character recognition,Tifinagh Handwritten Character Recognition
 tilt correction,Tilt Correction
 TIME,Time
 Time delay neural network,Time Delay Neural Network
 time sequence learning,Time Sequence Learning
-Time Series,Time Series
 time series,Time Series
 Time series classification,Time Series Classification
 Time series forecasting,Time Series Forecasting
 time series forecasting,Time Series Forecasting
 TIME SIGNALS,Time Signals
 time to market,Time To Market
-Time Warp Edit Distance,Time Warp Edit Distance
 time warping,Time Warping
 TIMED AUTOMATA,Timed Automata
 timed automata,Timed Automata
 Time-frequency analysis,Time-Frequency Analysis
-Time-Sequences,Time-Sequences
 TIME-SERIES,Time-Series
 time-series classification,Time-Series Classification
 Time-series data,Time-Series Data
 timing,Timing
-TiOx,TiOx
-TMIXT,TMIXT
 token,Token
 TOKEN RATIOS,Token Ratios
-Tooee,Tooee
 TOOL,Tool
-Tool,Tool
 toolbox,Toolbox
 toolbox architecture,Toolbox Architecture
 TOOLS,Tools
@@ -10196,9 +8557,7 @@ top-down,Top-Down
 Top-down derivation,Top-Down Derivation
 Top-down guidance,Top-Down Guidance
 topic keyword clustering,Topic Keyword Clustering
-Topic Modeling,Topic Modeling
 Topic models,Topic Modeling
-Topological,Topological
 topological and structural features,Topological And Structural Features
 topological attributes,Topological Attributes
 Topological feature,Topological Feature
@@ -10209,9 +8568,7 @@ topology-preserving mapping,Topology-Preserving Mapping
 total variation regularization,Total Variation Regularization
 total-trajectory-shape modelling,Total-Trajectory-Shape Modelling
 TOUCH,Touch
-Touch,Touch
 touch,Touch
-Touch & Write,Touch & Write
 touch dynamics,Touch Dynamics
 touch gestures,Touch Gestures
 Touch panel,Touch Panel
@@ -10219,7 +8576,6 @@ touch screen,Touch Screen
 touched character recognition,Touched Character Recognition
 touched character segmentation,Touched Character Segmentation
 touched cursive characters,Touched Cursive Characters
-Touching,Touching
 Touching and overlapping characters,Touching And Overlapping Characters
 Touching character,Touching Character
 touching character segmentation,Touching Character Segmentation
@@ -10238,23 +8594,18 @@ touching numeral segmentation,Touching Numeral Segmentation
 touching numeral strings,Touching Numeral Strings
 Touchless interfaces,Touchless Interfaces
 touchpad,Touchpad
-Touchscreen,Touchscreen
 touch-screen sensor,Touchscreen Sensor
-Trace,Trace
 trace transform,Trace Transform
 TRACEABILITY,Traceability
 tracing,Tracing
 TRACKING,Tracking
-Tracking,Tracking
 trademark,Trademark
 traditional Chinese,Traditional Chinese
 traditional cultures,Traditional Cultures
-traditional LeNet-5,traditional LeNet-5
 traditional Mongolian,Traditional Mongolian
 traffic prediction,Traffic Prediction
 Traffic sign detection,Traffic Sign Detection
 traffic sign recognition,Traffic Sign Recognition
-Training,Training
 training,Training
 Training acceleration,Training Acceleration
 training algorithm,Training Algorithms
@@ -10272,7 +8623,6 @@ training models,Training Models
 training neural networks,Training Neural Networks
 training phase,Training Phase
 training process,Training Process
-Training Sample Selection,Training Sample Selection
 training schedule,Training Schedule
 TRAINING SET,Training Set
 training set,Training Set
@@ -10282,7 +8632,6 @@ training set expansion,Training Set Expansion
 training set size,Training Set Size
 Training strategies,Training Strategy
 training strategy,Training Strategy
-Trajectory,Trajectory
 Trajectory analysis,Trajectory Analysis
 Trajectory construction models,Trajectory Construction Models
 trajectory estimation,Trajectory Estimation
@@ -10291,21 +8640,17 @@ trajectory recovery,Trajectory Recovery
 trajectory representation,Trajectory Representation
 transcranial magnetic stimulation,Transcranial Magnetic Stimulation
 transcranial sonography,Transcranial Sonography
-Transcribing,Transcribing
 transcribing,Transcribing
 transcript,Transcript
 transcript mapping,Transcript Mapping
 Transcript-image Alignment,Transcript-Image Alignment
 TRANSCRIPTION,Transcription
-Transcription,Transcription
 transcription,Transcription
 transcription alignment,Transcription Alignment
-Transcription Annotation,Transcription Annotation
 Transcription error,Transcription Error
 TRANSDUCERS,Transducers
 Transductive learning,Transductive Learning
 TL,Transfer Learning
-Transfer Learning,Transfer Learning
 Transfer learning,Transfer Learning
 transfer learning,Transfer Learning
 Transfer Learning (TF),Transfer Learning
@@ -10313,7 +8658,6 @@ transfer learning (TL),Transfer Learning
 Transferable belief model,Transferable Belief Model
 TRANSFORM,Transform
 TRANSFORMATION,Transformation
-Transformation,Transformation
 Transformation learning,Transformation Learning
 Transformation matrix,Transformation Matrix
 TRANSFORMATION MODEL,Transformation Model
@@ -10321,19 +8665,15 @@ Transformation reversal,Transformation Reversal
 transformation-independence,Transformation-Independence
 transformations,Transformations
 transformed domain feature,Transformed Domain Feature
-Transformer,Transformer
 Transformer model,Transformer Model
 TRANSFORMS,Transforms
 transforms,Transforms
 Transition count,Transition Count
 transition count,Transition Count
-Transition Feature,Transition Feature
 transition stroke,Transition Stroke
 TRANSITION TREE,Transition Tree
-Transkribus,Transkribus
 TRANSLATION,Translation
 translation,Translation
-Transliteration,Transliteration
 transliteration,Transliteration
 transparency,Transparency
 transparent neuronal networks,Transparent Neuronal Networks
@@ -10342,11 +8682,9 @@ TRANSPUTERS,Transputers
 trauma center,Trauma Center
 TREATMENT ALLOCATION,Treatment Allocation
 TREATMENT RANDOMIZATION SYSTEM,Treatment Randomization System
-Tree Augmented Naive Bayes Network,Tree Augmented Naive Bayes Network
 tree classifier,Tree Classifier
 Tree edit distance,Tree Edit Distance
 tree edit distance,Tree Edit Distance
-Tree Search Method,Tree Search Method
 TREE STRUCTURE,Tree Structure
 tree structure,Tree Structure
 tree-structure,Tree Structure
@@ -10358,30 +8696,17 @@ triangle geometry,Triangle Geometry
 Tri-axial accelerometer data,Tri-Axial Accelerometer Data
 Triboelectric nanogenerator,Triboelectric Nanogenerator
 triboelectric nanogenerator,Triboelectric Nanogenerator
-Trie,Trie
-Trie Lexicon,Trie Lexicon
-true DTW,true DTW
 truthing error,Truthing Error
-TS model,TS model
-TS-Fuzzy models,TS-Fuzzy models
-t-SNE,t-SNE
-Tulu,Tulu
-Tulu Script,Tulu Script
 TUMOR-CONTROL,Tumor-Control
-Tuning,Tuning
 turing tests,Turing Tests
-Turkish,Turkish
 Turkish handwriting recognition,Turkish Handwriting Recognition
-Tutorials,Tutorials
 twin support vector machine,Twin Support Vector Machine
 twins study,Twins Study
 Two Channel Convolutional Neural Network (TCCNN),Two Channel Convolutional Neural Network
-Two stage SVMs,Two stage SVMs
 Two-class classification,Two-Class Classification
 2D-HMM,Two-Dimensional Hidden Markov Model
 two-dimensional Hidden Markov Model,Two-Dimensional Hidden Markov Model
 2D-LDA,Two-Dimensional Linear Discriminant Analysis
-Two-Dimensional Linear Discriminant Analysis,Two-Dimensional Linear Discriminant Analysis
 Two-level,Two-Level
 Two-level design,Two-Level Design
 Two-pass approach to pattern classification,Two-Pass Approach To Pattern Classification
@@ -10394,14 +8719,10 @@ two-step algorithm,Two-Step Algorithm
 two-tier architecture,Two-Tier Architecture
 typeface,Typeface
 Types of Simulation,Types Of Simulation
-Typewriting,Typewriting
-Typing,Typing
 typing,Typing
 TYPISTS,Typists
 TYROSINE DEPLETION,Tyrosine Depletion
-UAM's,UAM's
 ubiquitous computing,Ubiquitous Computing
-Uighur,Uighur
 Uyghur alphabet,Uighur Alphabet
 Uyghur characters,Uighur Characters
 Uighur language,Uighur Language
@@ -10410,14 +8731,10 @@ Uyghur Language,Uighur Language
 Uygur Language,Uighur Language
 Uighur word,Uighur Words
 Uyghur words,Uighur Words
-Ukrainian Lexicography,Ukrainian Lexicography
-ULBP,ULBP
 Ultra-low resolution,Ultra-Low Resolution
 ultrasonic wave,Ultrasonic Wave
 ultrasound tomography,Ultrasound Tomography
 ultraviolet imaging,Ultraviolet Imaging
-UMLPDSV,UMLPDSV
-Uncertainty,Uncertainty
 uncertainty estimates,Uncertainty Estimates
 unconstrained,Unconstrained
 Unconstrained handwriting,Unconstrained Handwriting
@@ -10443,44 +8760,36 @@ underlying functions,Underlying Functions
 Under-resourced language,Under-Resourced Language
 Under-sampled bitmaps,Under-Sampled Bitmaps
 UNDERSTANDING,Understanding
-U-Net,U-Net
-Unicode,Unicode
 UNIFIED FRAMEWORK,Unified Framework
 Unified framework,Unified Framework
 uniform scaling,Uniform Scaling
 UNIPEN,Unipen
-Unipen,Unipen
 UNIPEN database,Unipen Database
 unipen dataset,Unipen Dataset
 UNIPEN online handwriting database,Unipen Online Handwriting Database
 United Moment Invariant (UMI),United Moment Invariant
 UNITS,Units
 UNIVERSAL,Universal
-Universal Language Model,Universal Language Model
 universal OCR,Universal OCR
 universal prior,Universal Prior
 Universal vocabulary,Universal Vocabulary
 universal writing model,Universal Writing Model
 "University library ""svetozar markovic""","University Library ""Svetozar Markovic"""
 UNKNOWN NUMBER,Unknown Number
-Unlabeled Data,Unlabeled Data
 Unlabeled data,Unlabeled Data
 Unrecognized patterns,Unrecognized Patterns
 unsegmented sequences,Unsegmented Sequences
 unstructured data,Unstructured Data
-Unsupervised,Unsupervised
 unsupervised,Unsupervised
 unsupervised approach,Unsupervised Approach
 Unsupervised clustering,Unsupervised Clustering
 unsupervised clustering,Unsupervised Clustering
-Unsupervised Documents Analysis,Unsupervised Documents Analysis
 Unsupervised domain adaptation,Unsupervised Domain Adaptation
 unsupervised domain adaptation,Unsupervised Domain Adaptation
 unsupervised feature learning,Unsupervised Feature Learning
 unsupervised feature selection,Unsupervised Feature Selection
 Unsupervised graphical symbol learning,Unsupervised Graphical Symbol Learning
 Unsupervised language model adaptation,Unsupervised Language Model Adaptation
-Unsupervised Learning,Unsupervised Learning
 Unsupervised learning,Unsupervised Learning
 unsupervised learning,Unsupervised Learning
 unsupervised learninig,Unsupervised Learninig
@@ -10492,11 +8801,7 @@ Upper envelope,Upper Envelope
 UPPER CASE LETTERS,Uppercase Letters
 Uppercase letters,Uppercase Letters
 urapidil,Urapidil
-Urdu,Urdu
-Urdu Character Recognition,Urdu Character Recognition
-Urdu Corpus,Urdu Corpus
 Urdu corpus,Urdu Corpus
-Urdu Digit Recognition,Urdu Digit Recognition
 Urdu handwriting recognition,Urdu Handwriting Recognition
 Urdu handwritten image database,Urdu Handwritten Image Database
 Urdu handwritten text,Urdu Handwritten Text
@@ -10504,10 +8809,8 @@ Urdu handwritten text detection,Urdu Handwritten Text Detection
 Urdu handwritten text recognition approaches,Urdu Handwritten Text Recognition Approaches
 Urdu initial half form,Urdu Initial Half Form
 Urdu language,Urdu Language
-Urdu OCR,Urdu OCR
 Urdu script,Urdu Script
 USABILITY,Usability
-Usability,Usability
 usability,Usability
 Usability engineering,Usability Engineering
 usability evaluation,Usability Evaluation
@@ -10526,26 +8829,19 @@ User interface design,User Interface Design
 user interface human factors,User Interface Human Factors
 User interface,User Interfaces
 user interface,User Interfaces
-User Interfaces,User Interfaces
 User interfaces,User Interfaces
 user interfaces,User Interfaces
 user modeling,User Modeling
 user profiling,User Profiling
 User studies,User Studies
-User-Centered Design,User-Centered Design
 user-centered systems,User-Centered Systems
-User-Computer Interaction,User-Computer Interaction
 USERS,Users
 users equal error rates,Users Equal Error Rates
-USPS,USPS
-Uzbek,Uzbek
-V4,V4
 VALID GENERALIZATION,Valid Generalization
 VALIDATION,Validation
 validation,Validation
 VALIDITY,Validity
 VARIABILITY,Variability
-Variability,Variability
 variability,Variability
 Variable duration HMM,Variable Duration HMM
 variable duration HMM (VDHMM),Variable Duration HMM
@@ -10557,14 +8853,10 @@ variables,Variables
 variance,Variance
 variational approximation,Variational Approximation
 VARIATIONAL INFERENCE,Variational Inference
-Variational Inference,Variational Inference
 Variational inference,Variational Inference
 variational methods,Variational Methods
 VARIATIONAL MODE DECOMPOSITION,Variational Mode Decomposition
 variational techniques,Variational Techniques
-VC,VC
-VC Dimension,VC Dimension
-VCMA,VCMA
 VECTOR,Vector
 vector,Vector
 vector graphics,Vector Graphics
@@ -10573,17 +8865,12 @@ vector skeleton,Vector Skeleton
 vector space model,Vector Space Model
 vectorisation,Vectorisation
 VECTORIZATION,Vectorization
-Vegetation,Vegetation
 VEIN PATTERNS,Vein Patterns
 VELOCITY,Velocity
-Velocity,Velocity
 Velocity beta impulse,Velocity Beta Impulse
-Venice Time Machine,Venice Time Machine
 VENTRAL STREAM,Ventral Stream
 ventral stream,Ventral Stream
-Verbal,Verbal
 VERIFICATION,Verification
-Verification,Verification
 verification,Verification
 verification of handwritten numerals,Verification Of Handwritten Numerals
 verification of postcode recognition,Verification Of Postcode Recognition
@@ -10594,30 +8881,20 @@ versatile document analysis systems,Versatile Document Analysis Systems
 versatility,Versatility
 vertical distortion,Vertical Distortion
 Vertical linear density,Vertical Linear Density
-Vertical Projection,Vertical Projection
 vertical projection histogram,Vertical Projection Histogram
 vertical text,Vertical Text
-VGG16,VGG16
-VGGNet,VGGNet
-VH2D,VH2D
-VHDL,VHDL
-VHDL generator,VHDL generator
 vibration signal,Vibration Signal
 VIDEO,Video
-Video OCR,Video OCR
 Video-OCR,Video OCR
 Video preprocessing,Video Preprocessing
-Video Segmentation,Video Segmentation
 Video segmentation,Video Segmentation
 video signal processing,Video Signal Processing
-Video Summarization,Video Summarization
 Video summarization,Video Summarization
 video summarization,Video Summarization
 Video text,Video Text
 video text detection,Video Text Detection
 Video text recognition,Video Text Recognition
 video text recognition,Video Text Recognition
-Videos,Videos
 Vietnamese online handwriting,Vietnamese Online Handwriting
 Vietnamese online handwriting recognition,Vietnamese Online Handwriting Recognition
 vigilance,Vigilance
@@ -10634,7 +8911,6 @@ VISION CORTEX,Vision Cortex
 vision enabled smart devices,Vision Enabled Smart Devices
 vision inspection,Vision Inspection
 Vision-based recognition system,Vision-Based Recognition System
-Visual Attention Networks,Visual Attention Networks
 visual data mining,Visual Data Mining
 visual databases,Visual Databases
 Visual element,Visual Element
@@ -10663,7 +8939,6 @@ visual vocabularie,Visual Vocabularie
 VISUAL WORD RECOGNITION,Visual Word Recognition
 Visual word recognition,Visual Word Recognition
 VISUAL-CORTEX,Visual-Cortex
-Visualization,Visualization
 Visually disabled,Visually Disabled
 visually impaired,Visually Impaired
 VISUAL-MOTOR INTEGRATION,Visual-Motor Integration
@@ -10676,9 +8951,6 @@ Viterbi decoding,Viterbi Decoding
 Viterbi estimation,Viterbi Estimation
 Viterbi score,Viterbi Score
 Viterbi score distribution,Viterbi Score Distribution
-VLAD,VLAD
-VLAD representation,VLAD representation
-VLSI,VLSI
 VLSI implementations,VLSI
 VOCABULARY OCR,Vocabulary OCR
 vocabulary size,Vocabulary Size
@@ -10688,17 +8960,12 @@ voice parameters,Voice Parameters
 VOICE RECORDINGS,Voice Recordings
 von Mises distribution,Von Mises Distribution
 Voronoi diagram,Voronoi Diagrams
-Voronoi Diagrams,Voronoi Diagrams
 Voronoi tessellation,Voronoi Tessellation
 VOTING,Voting
 voting,Voting
 vowel consonant clusters,Vowel Consonant Clusters
-Vowel Sign,Vowel Sign
-VQ,VQ
-v-SVM,v-SVM
 WACOM graphic tablet,WACOM Graphic Tablet
 Wagner-Fisher algorithm,Wagner-Fisher Algorithm
-Wagon,Wagon
 WAKE,Wake
 WALKING,Walking
 Wall detection,Wall Detection
@@ -10707,19 +8974,14 @@ warp correction,Warp Correction
 WARPING,Warping
 warping,Warping
 Warping based matching,Warping Based Matching
-Wasan,Wasan
-Water Reservoir,Water Reservoir
 Water reservoir,Water Reservoir
 water reservoir concept,Water Reservoir Concept
-Water Reservoir Feature,Water Reservoir Feature
 Water reservoir feature,Water Reservoir Feature
 water reservoir feature,Water Reservoir Feature
 watercolor,Watercolor
 watermarking,Watermarking
 Watermarking and information hiding in documents,Watermarking And Information Hiding In Documents
 watermarking regions,Watermarking Regions
-Watermarks,Watermarks
-Watershed Transform,Watershed Transform
 wavelet,Wavelet
 Wavelets,Wavelet
 wavelet analysis,Wavelet Analysis
@@ -10743,28 +9005,21 @@ Weak supervision,Weak Supervision
 weakly supervised,Weakly Supervised
 weakly supervised learning,Weakly Supervised Learning
 Wearable computers,Wearable Computers
-Wearable Computing,Wearable Computing
 Wearable computing,Wearable Computing
 wearable computing,Wearable Computing
 wearable device,Wearable Devices
 wearable devices,Wearable Devices
 wearable electronics,Wearable Electronics
 wearable gloves,Wearable Gloves
-Wearables,Wearables
 wearables,Wearables
-Web,Web
 web application,Web Application
-Web Apps,Web Apps
 web publishing,Web Publishing
 Web resources,Web Resources
 web security,Web Security
 Web service,Web Services
 web service,Web Services
-Web Services,Web Services
 Web-based handwriting mathematics system,Web-Based Handwriting Mathematics System
 web-based learning,Web-Based Learning
-WebKB,WebKB
-WebMath,WebMath
 Weight initialization,Weight Initialization
 weight sparsity,Weight Sparsity
 weighted Direct Matching Point,Weighted Direct Matching Point
@@ -10778,10 +9033,7 @@ weighted neighborhood,Weighted Neighborhood
 weighted phoneme,Weighted Phoneme
 weighted undirected graph,Weighted Undirected Graph
 weighted voting,Weighted Voting
-Weights,Weights
-Weightvector,Weightvector
 WEKA,Weka
-Weka,Weka
 WFST-based decoding,Wfst-Based Decoding
 whale optimization,Whale Optimization
 WHITEBOARD,Whiteboard
@@ -10795,13 +9047,10 @@ wide neural networks,Wide Neural Networks
 WiFi devices,Wifi Devices
 WiFi Signals,Wifi Signals
 WIGNER DISTRIBUTION,Wigner Distribution
-Wii Remote,Wii Remote
 wildcard likelihood,Wildcard Likelihood
 wildcards,Wildcards
-Windows 7,Windows 7
 Windows slippery,Windows Slippery
 winner takes all NN,Winner Takes All NN
-Wireless,Wireless
 Wireless communication,Wireless Communication
 Wireless fidelity,Wireless Fidelity
 WiFi sensing,Wireless Sensing
@@ -10831,18 +9080,14 @@ Word level script identification,Word Level Script Identification
 Word posterior probability,Word Posterior Probability
 word preprocessing,Word Preprocessing
 WORD RECOGNITION,Word Recognition
-Word Recognition,Word Recognition
 Word recognition,Word Recognition
 word recognition,Word Recognition
 WORD RECOGNITION AND CORRECTION,Word Recognition And Correction
 word recognition and correction,Word Recognition And Correction
 WORD RECOGNIZERS,Word Recognizers
 WORD RETRIEVAL,Word Retrieval
-Word Retrieval,Word Retrieval
 word retrieval,Word Retrieval
-Word Searching,Word Searching
 WORD SEGMENTATION,Word Segmentation
-Word Segmentation,Word Segmentation
 Word segmentation,Word Segmentation
 word segmentation,Word Segmentation
 word segmentation SIFT descriptor signature,Word Segmentation Sift Descriptor Signature
@@ -10850,7 +9095,6 @@ word segments,Word Segments
 word sequence recognition,Word Sequence Recognition
 word shape matching,Word Shape Matching
 Word slant estimation,Word Slant Estimation
-Word Spotting,Word Spotting
 Word spotting,Word Spotting
 word spotting,Word Spotting
 wordspotting,Word Spotting
@@ -10858,7 +9102,6 @@ Word-spotting,Word Spotting
 word-spotting,Word Spotting
 Word spotting Word annotation,Word Spotting Word Annotation
 word structure retrieval,Word Structure Retrieval
-Word Tokenization,Word Tokenization
 word transliteration,Word Transliteration
 word verification,Word Verification
 word-based,Word-Based
@@ -10872,16 +9115,13 @@ WORDS,Words
 WORKED EXAMPLES,Worked Examples
 WORKFLOW,Workflow
 WORKFLOWS,Workflow
-Working Memory,Working Memory
 working memory,Working Memory
 WORKING-MEMORY,Working Memory
 WORKING-MEMORY CAPACITY,Working-Memory Capacity
 WORK-LIFE BALANCE,Work-Life Balance
 wrapping,Wrapping
 wrinkliness,Wrinkliness
-Wrist,Wrist
 WRITER ADAPTATION,Writer Adaptation
-Writer Adaptation,Writer Adaptation
 Writer adaptation,Writer Adaptation
 writer adaptation,Writer Adaptation
 writer-adaptation,Writer Adaptation
@@ -10897,7 +9137,6 @@ writer-dependent,Writer Dependent
 WRITER DEPENDENT FEATURES,Writer Dependent Features
 writer gender prediction,Writer Gender Prediction
 WRITER IDENTIFICATION,Writer Identification
-Writer Identification,Writer Identification
 Writer identification,Writer Identification
 writer identification,Writer Identification
 Writer Identification (WI),Writer Identification
@@ -10923,7 +9162,6 @@ Writer-independent features,Writer-Independent Features
 Writer-independent signature verification,Writer-Independent Signature Verification
 WRITERS,Writers
 writer's invariants,Writer's Invariants
-Writing,Writing
 writing,Writing
 WRITING ACQUISITION,Writing Acquisition
 writing constraint,Writing Constraints
@@ -10966,20 +9204,10 @@ written language,Written Language
 Written text segmentation,Written Text Segmentation
 WRITTEN WORD PRODUCTION,Written Word Production
 WRITTEN WORDS,Written Words
-WWW,WWW
-XML,XML
-XOR bit-wise,XOR bit-wise
-Yaw,Yaw
 YOLO,Yolo
-Yolo,Yolo
 YOLOv3,Yolo
-Yoruba,Yoruba
-Y-Position,Y-Position
-Zaner-Bloser Copy Book Style,Zaner-Bloser Copy Book Style
-Zaner-Bloser Handwriting,Zaner-Bloser Handwriting
 Zernike Moment Invariant (ZMI),Zernike Moment Invariant
 Zernike moment,Zernike Moments
-Zernike Moments,Zernike Moments
 Zernike moments,Zernike Moments
 zero crossings of wavelet coefficients,Zero Crossings Of Wavelet Coefficients
 zero order Autonomous Learning Multiple Model (ALMMo) classifier,Zero Order Autonomous Learning Multiple Model (Almmo) Classifier
@@ -10997,17 +9225,11 @@ zone prominence,Zone Prominence
 zone-based density feature,Zone-Based Density Feature
 zone-line extraction,Zone-Line Extraction
 zone-wise features,Zone-Wise Features
-Zoning,Zoning
 zoning,Zoning
 zoning and neural network,Zoning And Neural Network
-Zoning Based Structural Features,Zoning Based Structural Features
-Zoning Mechanism,Zoning Mechanism
 zoning mechanism,Zoning Mechanism
 Zoning method,Zoning Method
 zoning method,Zoning Method
-Zoning Methods,Zoning Methods
 zoning technique,Zoning Technique
 Zoning Topologies,Zoning Topology
-Zoning Topology,Zoning Topology
 Z-ordering,Z-Ordering
-Zynq,Zynq


### PR DESCRIPTION
```py

with open('thesaurus_terms.csv',  "r", encoding="utf8", newline='') as csvfile:
    reader = csv.DictReader(csvfile, fieldnames=["label","replace_by"])
    thesau = [row for row in reader]

with open("clean_thesau.csv", "w", encoding="utf8", newline="") as csvfile:
    writer = csv.DictWriter(csvfile, fieldnames=["label", "replace by"])
    writer.writeheader()

    for row in thesau:
        if row["label"] != row["replace_by"]:
            writer.writerow({"label": row["label"], "replace by": row["replace_by"]})
```

En gros, retrait des équivalences inutiles.